### PR TITLE
Throw error from yup

### DIFF
--- a/lib/Form.tsx
+++ b/lib/Form.tsx
@@ -67,6 +67,10 @@ export default function Form({
     } catch (err) {
       const validationErrors: Errors = {};
 
+      if (!err.inner) {
+        throw err;
+      }
+
       err.inner.forEach((error: ValidationError) => {
         validationErrors[error.path] = error.message;
       });


### PR DESCRIPTION
Now it throws an error in case the validation process encounters a problem.

This improves debugging an error when using `yup`.