### PR TITLE
Skip Travis builds in documentation changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,16 @@ cache:
   directories:
     - node_modules
 
+before_install:
+- |
+    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+      TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
+    fi
+    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs|example))/' || {
+      echo "Only docs were updated, stopping build process."
+      exit
+    }
+
 install:
   - yarn
 


### PR DESCRIPTION
Travis was running builds even when only documentation files were edited.

Now Travis won't run if you have only edited files under these circumstances:

- Markdown files;
- Files inside example folder;
- Files inside docs folder;

Based on: https://github.com/facebook/react/pull/2000