### PR TITLE
Update TOC and `Contributing` section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ yarn add @rocketseat/unform
   - [Custom Elements](#custom-elements)
     - [React Select](#react-select)
     - [React Datepicker](#react-datepicker)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Guides
 
@@ -351,13 +353,9 @@ function App() {
 }
 ```
 
-## Contribute
+## Contributing
 
-1. Fork it
-2. Create your feature branch (git checkout -b my-new-feature)
-3. Commit your changes (git commit -am 'Add some feature')
-4. Push to the branch (git push origin my-new-feature)
-5. Create new Pull Request
+Before submitting a pull request, please read our [Contributing Guide](.github/CONTRIBUTING.md). It contains a set of instructions and guidelines that aim to make the contribution process easy and frictionless.
 
 ## License
 


### PR DESCRIPTION
Update `Table of contents` to match `Contributing` section header and also add the missing section `License`.

In the `Contributing` section, replace the old steps to contribute with an intro and a link to our Contributing Guide.