### PR TITLE
Remove skip rule from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,6 @@ cache:
   directories:
     - node_modules
 
-before_install:
-- |
-    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-      TRAVIS_COMMIT_RANGE="FETCH_HEAD...$TRAVIS_BRANCH"
-    fi
-    git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs|example))/' || {
-      echo "Only docs were updated, stopping build process."
-      exit
-    }
-
 install:
   - yarn
 


### PR DESCRIPTION
Travis was skipping builds in PR's when a single commit changes only docs or markdowns.

For now i think the better for us is to add [skip ci] in commit message then Travis will skip it.