### PR TITLE
chore: Make select placeholder optional

### DIFF
--- a/__tests__/Form.spec.tsx
+++ b/__tests__/Form.spec.tsx
@@ -137,7 +137,11 @@ describe("Form", () => {
     const { getByTestId, getByLabelText } = render(
       <Form onSubmit={(_, { resetForm }) => resetForm()}>
         <Input name="name" />
-        <Select name="tech" options={[{ id: "node", title: "NodeJS" }]} />
+        <Select
+          name="tech"
+          placeholder="Select..."
+          options={[{ id: "node", title: "NodeJS" }]}
+        />
       </Form>
     );
 

--- a/__tests__/components/Select.spec.tsx
+++ b/__tests__/components/Select.spec.tsx
@@ -41,14 +41,9 @@ describe("Form", () => {
       tech: Yup.string().required("Tech is required")
     });
 
-    const initialData = {
-      tech: ""
-    };
-
     const { getByText, getByTestId } = render(
-      <Form schema={schema} initialData={initialData} onSubmit={jest.fn()}>
+      <Form schema={schema} onSubmit={jest.fn()}>
         <Select
-          placeholder="Select..."
           options={[{ id: "node", title: "NodeJS" }]}
           name="tech"
           label="Tech"

--- a/__tests__/components/Select.spec.tsx
+++ b/__tests__/components/Select.spec.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import 'react-testing-library/cleanup-after-each';
 import 'jest-dom/extend-expect';
-import {
- act, render, fireEvent, wait,
-} from 'react-testing-library';
+import { act, render, fireEvent, wait } from 'react-testing-library';
 import * as Yup from 'yup';
 
 import { Form, Select } from '../../lib';
@@ -17,28 +15,42 @@ describe('Form', () => {
           name="tech"
           label="Tech"
         />
-      </Form>,
+      </Form>
     );
 
     expect(!!getByText('Tech')).toBe(true);
   });
 
-  it("should display placeholder", () => {
+  it('should display placeholder', () => {
     const { getByText } = render(
       <Form onSubmit={jest.fn()}>
         <Select
           placeholder="Select..."
-          options={[{ id: "node", title: "NodeJS" }]}
+          options={[{ id: 'node', title: 'NodeJS' }]}
           name="tech"
           label="Tech"
         />
       </Form>
     );
 
-    expect(!!getByText("Select...")).toBe(true);
+    expect(!!getByText('Select...')).toBe(true);
   });
 
-  it("should display error", async () => {
+  it('shoud use default placeholder when no one is defined', () => {
+    const { getByDisplayValue } = render(
+      <Form onSubmit={jest.fn()}>
+        <Select
+          options={[{ id: 'node', title: 'NodeJS' }]}
+          name="tech"
+          label="Tech"
+        />
+      </Form>
+    );
+
+    expect(!!getByDisplayValue('')).toBe(true);
+  });
+
+  it('should display error', async () => {
     const schema = Yup.object().shape({
       tech: Yup.string().required('Tech is required'),
     });
@@ -50,7 +62,7 @@ describe('Form', () => {
           name="tech"
           label="Tech"
         />
-      </Form>,
+      </Form>
     );
 
     act(() => {
@@ -73,7 +85,7 @@ describe('Form', () => {
           name="tech"
           label="Tech"
         />
-      </Form>,
+      </Form>
     );
 
     act(() => {
@@ -88,7 +100,7 @@ describe('Form', () => {
       },
       {
         resetForm: expect.any(Function),
-      },
+      }
     );
   });
 

--- a/__tests__/components/Select.spec.tsx
+++ b/__tests__/components/Select.spec.tsx
@@ -21,14 +21,34 @@ describe("Form", () => {
     expect(!!getByText("Tech")).toBe(true);
   });
 
+  it("should display placeholder", () => {
+    const { getByText } = render(
+      <Form onSubmit={jest.fn()}>
+        <Select
+          placeholder="Select..."
+          options={[{ id: "node", title: "NodeJS" }]}
+          name="tech"
+          label="Tech"
+        />
+      </Form>
+    );
+
+    expect(!!getByText("Select...")).toBe(true);
+  });
+
   it("should display error", async () => {
     const schema = Yup.object().shape({
       tech: Yup.string().required("Tech is required")
     });
 
+    const initialData = {
+      tech: ""
+    };
+
     const { getByText, getByTestId } = render(
-      <Form schema={schema} onSubmit={jest.fn()}>
+      <Form schema={schema} initialData={initialData} onSubmit={jest.fn()}>
         <Select
+          placeholder="Select..."
           options={[{ id: "node", title: "NodeJS" }]}
           name="tech"
           label="Tech"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -9,6 +9,7 @@ import ReactSelect from "./components/ReactSelect";
 const schema = Yup.object().shape({
   name: Yup.string().required(),
   profile: Yup.string().required(),
+  theme: Yup.string().required(),
   tech: Yup.string().required(),
   date: Yup.date().required(),
   people: Yup.array(Yup.string())
@@ -31,6 +32,7 @@ const schema = Yup.object().shape({
 interface Data {
   name: string;
   profile: string;
+  theme: string;
   tech: string;
   people: string[];
   date: Date;
@@ -47,6 +49,7 @@ function App() {
   const [formData] = useState<Data>({
     name: "Diego",
     profile: "CTO na Rocketseat",
+    theme: "",
     tech: "node",
     people: ["1", "3"],
     date: new Date(),
@@ -70,6 +73,16 @@ function App() {
     >
       <Input name="name" label="Nome" />
       <Textarea name="profile" label="Perfil" />
+
+      <Select
+        name="theme"
+        placeholder="Selecione..."
+        options={[
+          { id: "dracula", title: "Dracula" },
+          { id: "material", title: "Material" },
+          { id: "shades-of-purple", title: "Shades of Purple" }
+        ]}
+      />
 
       <ReactSelect
         name="tech"

--- a/lib/components/Select.tsx
+++ b/lib/components/Select.tsx
@@ -17,16 +17,18 @@ export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
 export default function Select({
   name,
   label,
-  placeholder,
+  placeholder = '',
+  defaultValue = '',
   options,
   ...rest
 }: SelectProps) {
-  const defaultPlaceholderValue = "";
-  const defaultPlaceholderText = "";
   const ref = useRef<HTMLSelectElement>(null);
   const {
- fieldName, registerField, defaultValue, error,
-} = useField(name);
+    fieldName,
+    registerField,
+    defaultValue: initialData,
+    error,
+  } = useField(name);
 
   useEffect(() => {
     if (ref.current) {
@@ -43,12 +45,12 @@ export default function Select({
         multiple={false}
         id={fieldName}
         name={fieldName}
-        defaultValue={defaultValue || defaultPlaceholderValue}
+        defaultValue={initialData || defaultValue}
         aria-label={fieldName}
         ref={ref}
       >
-        <option value={defaultPlaceholderValue} disabled hidden>
-          {placeholder || defaultPlaceholderText}
+        <option value={defaultValue} disabled hidden>
+          {placeholder}
         </option>
         {options.map(({ id, title }: Option) => (
           <option key={id} value={id}>

--- a/lib/components/Select.tsx
+++ b/lib/components/Select.tsx
@@ -21,6 +21,8 @@ export default function Select({
   options,
   ...rest
 }: Props) {
+  const defaultPlaceholderValue = "";
+  const defaultPlaceholderText = "";
   const ref = useRef<HTMLSelectElement>(null);
   const { fieldName, registerField, defaultValue, error } = useField(name);
 
@@ -39,15 +41,13 @@ export default function Select({
         multiple={false}
         id={fieldName}
         name={fieldName}
-        defaultValue={defaultValue}
+        defaultValue={defaultValue || defaultPlaceholderValue}
         aria-label={fieldName}
         ref={ref}
       >
-        {placeholder && (
-          <option value="" disabled hidden>
-            {placeholder}
-          </option>
-        )}
+        <option value={defaultPlaceholderValue} disabled hidden>
+          {placeholder || defaultPlaceholderText}
+        </option>
         {options.map(({ id, title }: Option) => (
           <option key={id} value={id}>
             {title}

--- a/lib/components/Select.tsx
+++ b/lib/components/Select.tsx
@@ -14,11 +14,16 @@ export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   options: Option[];
 }
 
+const defaultProps: Partial<SelectProps> = {
+  placeholder: '',
+  defaultValue: '',
+};
+
 function Select({
   name,
   label,
-  placeholder = '',
-  defaultValue = '',
+  placeholder,
+  defaultValue,
   options,
   ...rest
 }: SelectProps) {
@@ -63,5 +68,7 @@ function Select({
     </>
   );
 }
+
+Select.defaultProps = defaultProps;
 
 export default Select;

--- a/lib/components/Select.tsx
+++ b/lib/components/Select.tsx
@@ -1,4 +1,9 @@
-import React, { SelectHTMLAttributes, useEffect, useRef } from 'react';
+import React, {
+  SelectHTMLAttributes,
+  FunctionComponent,
+  useEffect,
+  useRef,
+} from 'react';
 
 import useField from '../useField';
 
@@ -14,14 +19,19 @@ export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   options: Option[];
 }
 
-export default function Select({
+const defaultProps: Partial<SelectProps> = {
+  placeholder: '',
+  defaultValue: '',
+};
+
+const Select: FunctionComponent<SelectProps> = ({
   name,
   label,
-  placeholder = '',
-  defaultValue = '',
+  placeholder,
+  defaultValue,
   options,
   ...rest
-}: SelectProps) {
+}) => {
   const ref = useRef<HTMLSelectElement>(null);
   const {
     fieldName,
@@ -62,4 +72,8 @@ export default function Select({
       {error && <span>{error}</span>}
     </>
   );
-}
+};
+
+Select.defaultProps = defaultProps;
+
+export default Select;

--- a/lib/components/Select.tsx
+++ b/lib/components/Select.tsx
@@ -1,9 +1,4 @@
-import React, {
-  SelectHTMLAttributes,
-  FunctionComponent,
-  useEffect,
-  useRef,
-} from 'react';
+import React, { SelectHTMLAttributes, useEffect, useRef } from 'react';
 
 import useField from '../useField';
 
@@ -19,19 +14,14 @@ export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   options: Option[];
 }
 
-const defaultProps: Partial<SelectProps> = {
-  placeholder: '',
-  defaultValue: '',
-};
-
-const Select: FunctionComponent<SelectProps> = ({
+function Select({
   name,
   label,
-  placeholder,
-  defaultValue,
+  placeholder = '',
+  defaultValue = '',
   options,
   ...rest
-}) => {
+}: SelectProps) {
   const ref = useRef<HTMLSelectElement>(null);
   const {
     fieldName,
@@ -72,8 +62,6 @@ const Select: FunctionComponent<SelectProps> = ({
       {error && <span>{error}</span>}
     </>
   );
-};
-
-Select.defaultProps = defaultProps;
+}
 
 export default Select;

--- a/lib/components/Select.tsx
+++ b/lib/components/Select.tsx
@@ -10,10 +10,17 @@ interface Option {
 interface Props extends SelectHTMLAttributes<HTMLSelectElement> {
   name: string;
   label?: string;
+  placeholder?: string;
   options: Option[];
 }
 
-export default function Select({ name, label, options, ...rest }: Props) {
+export default function Select({
+  name,
+  label,
+  placeholder,
+  options,
+  ...rest
+}: Props) {
   const ref = useRef<HTMLSelectElement>(null);
   const { fieldName, registerField, defaultValue, error } = useField(name);
 
@@ -36,7 +43,11 @@ export default function Select({ name, label, options, ...rest }: Props) {
         aria-label={fieldName}
         ref={ref}
       >
-        <option value="">Selecione...</option>
+        {placeholder && (
+          <option value="" disabled hidden>
+            {placeholder}
+          </option>
+        )}
         {options.map(({ id, title }: Option) => (
           <option key={id} value={id}>
             {title}


### PR DESCRIPTION
Currently, the `Select` component always display an option with the `Selecione...` text. This PR treats this *predefined text* as `placeholder` of the `Select` component.

___
**before**

```javascript
<Select
  name="theme"
  options={[
    { id: "dracula", title: "Dracula" },
    { id: "material", title: "Material" },
    { id: "shades-of-purple", title: "Shades of Purple" }
  ]}
/>

// will render

<select name="theme">
  // default and no customizable placeholder below
  <option value="">Selecione...</option>
  <option value="dracula">Dracula</option>
  <option value="shades-of-purple">Shades of Purple</option>
</select>
```

___
**after**

1. With placeholder prop:

```javascript
<Select
  name="theme"
  placeholder="Select a theme..." // <- 1. new prop goes here
  options={[
    { id: "dracula", title: "Dracula" },
    { id: "material", title: "Material" },
    { id: "shades-of-purple", title: "Shades of Purple" }
  ]}
/>

// will render

<select name="theme">
  // 2. and the placeholder will be rendered here
  // this option will be selected if no `defaultValue` is provided
  <option value="" disabled hidden>Select a theme...</option> 
  <option value="dracula">Dracula</option>
  <option value="shades-of-purple">Shades of Purple</option>
</select>
```

2. Without placeholder prop:

```javascript
<Select
  name="theme"
  options={[
    { id: "dracula", title: "Dracula" },
    { id: "material", title: "Material" },
    { id: "shades-of-purple", title: "Shades of Purple" }
  ]}
/>

// will render

<select name="theme">
  // empty option, similar to input behavior without a placeholder
  // this option will be selected if no `defaultValue` is provided
  <option value="" disabled hidden></option>
  <option value="dracula">Dracula</option>
  <option value="shades-of-purple">Shades of Purple</option>
</select>
```