### PR TITLE
docs: Add section about skipping building process

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -195,7 +195,7 @@ Issues and pull request can be referenced on the footer: #3 #12
 
 ### Skipping building process
 
-By default, Travis CI automatically run the building process whenever you push changes. If your commit is about documentation or meta files, you can override this behavior by adding a **[skip ci]** tag anywhere in a commit’s **footer**. This not only skips the marked commit, but also **all other commits** in the push.
+By default, Travis CI automatically runs the building process whenever you push changes. If your commit is about documentation or meta files, you can override this behavior by adding a **[skip ci]** tag anywhere in a commit’s **footer**. This not only skips the marked commit, but also **all other commits** in the push.
 
 ### Why all these rules?
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,6 +14,7 @@
   - [Code](#code)
     - [Dev environment](#dev-environment)
 - [Commiting](#commiting)
+  - [Skipping building process](#skipping-building-process)
   - [Why all this rules?](#why-all-this-rules)
 - [Submitting a pull request](#submitting-a-pull-request)
 
@@ -153,6 +154,7 @@ To ensure that a commit is valid, easy to read, and changelog-ready, we have a h
 - The footer:
   - Must have a leading blank line;
   - Each line must be limited to 72 characters or less;
+  - If your commit is about documentation or meta files, please add the tag **[skip ci]** to skip the building process.
   - If needed, reference to issues and pull requests must be made here in the last line.
 
 You also should follow these general guidelines when committing:
@@ -191,6 +193,10 @@ text editors are capable of automating this.
 Issues and pull request can be referenced on the footer: #3 #12
 ```
 
+### Skipping building process
+
+By default, Travis CI automatically run the building process whenever you push changes. If your commit is about documentation or meta files, you can override this behavior by adding a **[skip ci]** tag anywhere in a commit’s **footer**. This not only skips the marked commit, but also **all other commits** in the push.
+
 ### Why all these rules?
 
 We try to enforce these rules for the following reasons:
@@ -211,4 +217,3 @@ Before submitting a pull request, please make sure the following is done:
 - If you’ve fixed a bug or added code that should be tested, **add tests**;
 - Ensure the test suite passes;
 - Ensure your commit is validated;
-- If your pull request is about documentation or meta files, please add the tag **[skip ci]** in the title.


### PR DESCRIPTION
There was an erroneous info in the PR section: Travis CI don't check for **[skip ci]** at the PR level but rather at the commit level.

To fix that, add a new section about skipping building process.

<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/unform/blob/master/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- Ensure you have added or ran the appropriate tests for your PR -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
<!--- Describe the change below, including rationale and design decisions -->

<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->

**Additional context**
<!-- Add any other context or screenshots about the feature request here. -->
