### PR TITLE
docs: Add description to the Initial Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ function App() {
 
 ### Initial data
 
+_Optional_: Here you can set what the initial data for each field will be, you store the initial field values into a variable and load it in the `Form` using the prop `initialData`.
+
 ```js
 import React from "react";
 import { Form, Input, Scope } from "@rocketseat/unform";


### PR DESCRIPTION
Adds text information on how to set up the Initial Data property to the respective section in the readme.

[skip ci]
