### PR TITLE
Feature/multiple refs on register field

### DIFF
--- a/__tests__/components/Choice.spec.tsx
+++ b/__tests__/components/Choice.spec.tsx
@@ -1,0 +1,257 @@
+import React from "react";
+import "react-testing-library/cleanup-after-each";
+import "jest-dom/extend-expect";
+import { act, render, fireEvent, wait } from "react-testing-library";
+import * as Yup from "yup";
+
+import { Form, Choice } from "../../lib";
+
+const expectCheckbox = (field: HTMLElement, checked: boolean) => {
+  expect((field as HTMLInputElement).checked).toBe(checked);
+};
+
+describe("Form", () => {
+  it("should return undefined if no option select when multiple", () => {
+    const submitMock = jest.fn();
+
+    const { getByTestId } = render(
+      <Form onSubmit={submitMock}>
+        <Choice
+          name="tech"
+          multiple
+          options={[
+            { id: "node", label: "NodeJS" },
+            { id: "react", label: "ReactJS" },
+            { id: "rn", label: "React Native" }
+          ]}
+        />
+      </Form>
+    );
+
+    fireEvent.submit(getByTestId("form"));
+
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        tech: undefined
+      },
+      {
+        resetForm: expect.any(Function)
+      }
+    );
+  });
+
+  it("should return undefined if no option select", () => {
+    const submitMock = jest.fn();
+
+    const { getByTestId } = render(
+      <Form onSubmit={submitMock}>
+        <Choice
+          name="tech"
+          options={[
+            { id: "node", label: "NodeJS" },
+            { id: "react", label: "ReactJS" },
+            { id: "rn", label: "React Native" }
+          ]}
+        />
+      </Form>
+    );
+
+    fireEvent.submit(getByTestId("form"));
+
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        tech: undefined
+      },
+      {
+        resetForm: expect.any(Function)
+      }
+    );
+  });
+
+  it("should return value as array if multiple", () => {
+    const submitMock = jest.fn();
+
+    const { getByTestId, getByLabelText } = render(
+      <Form onSubmit={submitMock}>
+        <Choice
+          name="tech"
+          multiple
+          options={[
+            { id: "node", label: "NodeJS" },
+            { id: "react", label: "ReactJS" },
+            { id: "rn", label: "React Native" }
+          ]}
+        />
+      </Form>
+    );
+
+    act(() => {
+      fireEvent.click(getByLabelText("NodeJS"));
+      fireEvent.click(getByLabelText("ReactJS"));
+    });
+
+    fireEvent.submit(getByTestId("form"));
+
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        tech: ["node", "react"]
+      },
+      {
+        resetForm: expect.any(Function)
+      }
+    );
+  });
+
+  it("should return value as string unless multiple", () => {
+    const submitMock = jest.fn();
+
+    const { getByTestId, getByLabelText } = render(
+      <Form onSubmit={submitMock}>
+        <Choice
+          name="tech"
+          options={[
+            { id: "node", label: "NodeJS" },
+            { id: "react", label: "ReactJS" },
+            { id: "rn", label: "React Native" }
+          ]}
+        />
+      </Form>
+    );
+
+    act(() => {
+      fireEvent.click(getByLabelText("NodeJS"));
+      fireEvent.click(getByLabelText("React Native"));
+    });
+
+    fireEvent.submit(getByTestId("form"));
+
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        tech: "rn"
+      },
+      {
+        resetForm: expect.any(Function)
+      }
+    );
+  });
+
+  it("should return value as string if only one option supplied", () => {
+    const submitMock = jest.fn();
+
+    const { getByTestId, getByLabelText } = render(
+      <Form onSubmit={submitMock}>
+        <Choice name="tech" options={[{ id: "node", label: "NodeJS" }]} />
+      </Form>
+    );
+
+    act(() => {
+      fireEvent.click(getByLabelText("NodeJS"));
+    });
+
+    fireEvent.submit(getByTestId("form"));
+
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        tech: "node"
+      },
+      {
+        resetForm: expect.any(Function)
+      }
+    );
+  });
+
+  it("should display labels if specified", () => {
+    const { getByText } = render(
+      <Form onSubmit={jest.fn()}>
+        <Choice options={[{ id: "node", label: "NodeJS" }]} name="tech" />
+      </Form>
+    );
+
+    expect(getByText("NodeJS")).toBeDefined();
+  });
+
+  it("should not display labels unless specified", () => {
+    const { getByText } = render(
+      <Form onSubmit={jest.fn()}>
+        <Choice options={[{ id: "node" }]} name="tech" />
+      </Form>
+    );
+
+    expect(() => getByText("NodeJS")).toThrow(/^Unable to find an element.*/);
+  });
+
+  it("should display errors", async () => {
+    const schema = Yup.object().shape({
+      tech: Yup.string().required("Tech is required")
+    });
+
+    const { getByText, getByTestId } = render(
+      <Form schema={schema} onSubmit={jest.fn()}>
+        <Choice options={[{ id: "node", label: "NodeJS" }]} name="tech" />
+      </Form>
+    );
+
+    act(() => {
+      fireEvent.submit(getByTestId("form"));
+    });
+
+    await wait(() => expect(!!getByText("Tech is required")).toBe(true));
+  });
+
+  it("should default check field if initialData supplied as array", async () => {
+    const { getByLabelText } = render(
+      <Form onSubmit={() => {}} initialData={{ tech: ["node", "react"] }}>
+        <Choice
+          name="tech"
+          multiple
+          options={[
+            { id: "node", label: "NodeJS" },
+            { id: "react", label: "ReactJS" },
+            { id: "rn", label: "React Native" }
+          ]}
+        />
+      </Form>
+    );
+    expectCheckbox(getByLabelText("NodeJS"), true);
+    expectCheckbox(getByLabelText("ReactJS"), true);
+    expectCheckbox(getByLabelText("React Native"), false);
+  });
+
+  it("should default check field if initialData supplied as string", async () => {
+    const { getByLabelText } = render(
+      <Form onSubmit={() => {}} initialData={{ tech: "react" }}>
+        <Choice
+          name="tech"
+          multiple
+          options={[
+            { id: "node", label: "NodeJS" },
+            { id: "react", label: "ReactJS" },
+            { id: "rn", label: "React Native" }
+          ]}
+        />
+      </Form>
+    );
+    expectCheckbox(getByLabelText("NodeJS"), false);
+    expectCheckbox(getByLabelText("ReactJS"), true);
+    expectCheckbox(getByLabelText("React Native"), false);
+  });
+
+  it("should not default check field unless initialData supplied", async () => {
+    const { getByLabelText } = render(
+      <Form onSubmit={() => {}}>
+        <Choice
+          name="tech"
+          multiple
+          options={[
+            { id: "node", label: "NodeJS" },
+            { id: "react", label: "ReactJS" },
+            { id: "rn", label: "React Native" }
+          ]}
+        />
+      </Form>
+    );
+    expectCheckbox(getByLabelText("NodeJS"), false);
+    expectCheckbox(getByLabelText("ReactJS"), false);
+    expectCheckbox(getByLabelText("React Native"), false);
+  });
+});

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,31 +3,33 @@ import { hot } from 'react-hot-loader/root';
 import * as Yup from 'yup';
 
 import {
- Form, Input, Select, Scope, SubmitHandler,
+ Form, Input, Select, Scope, SubmitHandler, Choice,
 } from '../../lib';
 import DatePicker from './components/DatePicker';
 import ReactSelect from './components/ReactSelect';
 
 const schema = Yup.object().shape({
-  name: Yup.string().required(),
-  profile: Yup.string().required(),
-  tech: Yup.string().required(),
-  date: Yup.date().required(),
-  people: Yup.array(Yup.string())
-    .min(2)
-    .required(),
-  billingAddress: Yup.object().shape({
-    street: Yup.string().required(),
-    number: Yup.string().required(),
-  }),
-  shippingAddress: Yup.object().when('$useShippingAsBilling', {
-    is: false,
-    then: Yup.object().shape({
-      street: Yup.string().required(),
-      number: Yup.string().required(),
-    }),
-    otherwise: Yup.object().strip(true),
-  }),
+  // name: Yup.string().required(),
+  // profile: Yup.string().required(),
+  // tech: Yup.string().required(),
+  // date: Yup.date().required(),
+  // people: Yup.array(Yup.string())
+  //   .min(2)
+  //   .required(),
+  // billingAddress: Yup.object().shape({
+  //   street: Yup.string().required(),
+  //   number: Yup.string().required()
+  // }),
+  // shippingAddress: Yup.object().when("$useShippingAsBilling", {
+  //   is: false,
+  //   then: Yup.object().shape({
+  //     street: Yup.string().required(),
+  //     number: Yup.string().required()
+  //   }),
+  //   otherwise: Yup.object().strip(true)
+  // }),
+  teste: Yup.array(Yup.string()),
+  teste2: Yup.string().required(),
 });
 
 interface Data {
@@ -39,12 +41,11 @@ interface Data {
   billingAddress: {
     number: number;
   };
+  teste?: string[];
 }
 
 function App() {
-  const [useShippingAsBilling, setUseShippingAsBilling] = useState<boolean>(
-    true,
-  );
+  const [useShippingAsBilling, setUseShippingAsBilling] = useState<boolean>(true);
 
   const [formData] = useState<Data>({
     name: 'Diego',
@@ -55,6 +56,7 @@ function App() {
     billingAddress: {
       number: 833,
     },
+    teste: ['1', '3'],
   });
 
   const handleSubmit: SubmitHandler<Data> = (data, { resetForm }) => {
@@ -70,6 +72,28 @@ function App() {
       schema={schema}
       onSubmit={handleSubmit}
     >
+      <Choice
+        name="teste"
+        options={[
+          { id: '1', label: 'Um' },
+          { id: '2', label: 'Dois' },
+          { id: '3', label: 'Tres' },
+          { id: '4', label: 'Quatro' },
+        ]}
+        multiple
+      />
+      <br />
+      <Choice
+        name="teste2"
+        options={[
+          { id: '1', label: 'Um' },
+          { id: '2', label: 'Dois' },
+          { id: '3', label: 'Tres' },
+          { id: '4', label: 'Quatro' },
+        ]}
+      />
+      <br />
+      {/*
       <Input name="name" label="Nome" />
       <Input multiline name="profile" label="Perfil" />
 
@@ -112,6 +136,7 @@ function App() {
         <Input name="street" />
         <Input name="number" />
       </Scope>
+      */}
 
       <button type="submit">Enviar</button>
     </Form>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,33 +3,34 @@ import { hot } from 'react-hot-loader/root';
 import * as Yup from 'yup';
 
 import {
- Form, Input, Select, Scope, SubmitHandler, Choice,
+ Form, Input, Scope, SubmitHandler, Choice,
 } from '../../lib';
 import DatePicker from './components/DatePicker';
 import ReactSelect from './components/ReactSelect';
 
 const schema = Yup.object().shape({
-  // name: Yup.string().required(),
-  // profile: Yup.string().required(),
-  // tech: Yup.string().required(),
-  // date: Yup.date().required(),
-  // people: Yup.array(Yup.string())
-  //   .min(2)
-  //   .required(),
-  // billingAddress: Yup.object().shape({
-  //   street: Yup.string().required(),
-  //   number: Yup.string().required()
-  // }),
-  // shippingAddress: Yup.object().when("$useShippingAsBilling", {
-  //   is: false,
-  //   then: Yup.object().shape({
-  //     street: Yup.string().required(),
-  //     number: Yup.string().required()
-  //   }),
-  //   otherwise: Yup.object().strip(true)
-  // }),
-  teste: Yup.array(Yup.string()),
-  teste2: Yup.string().required(),
+  name: Yup.string().required(),
+  profile: Yup.string().required(),
+  tech: Yup.string().required(),
+  date: Yup.date().required(),
+  people: Yup.array(Yup.string())
+    .min(2)
+    .required(),
+  billingAddress: Yup.object().shape({
+    street: Yup.string().required(),
+    number: Yup.string().required(),
+  }),
+  shippingAddress: Yup.object().when('$useShippingAsBilling', {
+    is: false,
+    then: Yup.object().shape({
+      street: Yup.string().required(),
+      number: Yup.string().required(),
+    }),
+    otherwise: Yup.object().strip(true),
+  }),
+  choice: Yup.array(Yup.string()),
+  choice2: Yup.string().required(),
+  choice3: Yup.string().required(),
 });
 
 interface Data {
@@ -41,7 +42,7 @@ interface Data {
   billingAddress: {
     number: number;
   };
-  teste?: string[];
+  choice?: string[];
 }
 
 function App() {
@@ -56,7 +57,7 @@ function App() {
     billingAddress: {
       number: 833,
     },
-    teste: ['1', '3'],
+    choice: ['1', '3'],
   });
 
   const handleSubmit: SubmitHandler<Data> = (data, { resetForm }) => {
@@ -72,28 +73,6 @@ function App() {
       schema={schema}
       onSubmit={handleSubmit}
     >
-      <Choice
-        name="teste"
-        options={[
-          { id: '1', label: 'Um' },
-          { id: '2', label: 'Dois' },
-          { id: '3', label: 'Tres' },
-          { id: '4', label: 'Quatro' },
-        ]}
-        multiple
-      />
-      <br />
-      <Choice
-        name="teste2"
-        options={[
-          { id: '1', label: 'Um' },
-          { id: '2', label: 'Dois' },
-          { id: '3', label: 'Tres' },
-          { id: '4', label: 'Quatro' },
-        ]}
-      />
-      <br />
-      {/*
       <Input name="name" label="Nome" />
       <Input multiline name="profile" label="Perfil" />
 
@@ -136,7 +115,32 @@ function App() {
         <Input name="street" />
         <Input name="number" />
       </Scope>
-      */}
+
+      <br />
+
+      <Choice
+        name="choice"
+        options={[
+          { id: '1', label: 'Um' },
+          { id: '2', label: 'Dois' },
+          { id: '3', label: 'Tres' },
+          { id: '4', label: 'Quatro' },
+        ]}
+        multiple
+      />
+      <br />
+      <Choice
+        name="choice2"
+        options={[
+          { id: '1', label: 'Um' },
+          { id: '2', label: 'Dois' },
+          { id: '3', label: 'Tres' },
+          { id: '4', label: 'Quatro' },
+        ]}
+      />
+      <br />
+      <Choice name="choice3" options={[{ id: 'sim', label: 'Aceito os termos...' }]} />
+      <br />
 
       <button type="submit">Enviar</button>
     </Form>

--- a/lib/Form.tsx
+++ b/lib/Form.tsx
@@ -106,8 +106,9 @@ export default function Form({
     }
   }
 
-  function registerField(field: UnformField) {
-    setFields(state => [...state, field]);
+  function registerField(field: Field) {
+    if (!fields.find(f => f.name === field.name))
+      setFields(state => [...state, field]);
   }
 
   function unregisterField(name: string) {

--- a/lib/Form.tsx
+++ b/lib/Form.tsx
@@ -47,9 +47,9 @@ export default function Form({
     const data = {};
 
     fields.forEach(({
- name, ref, path, parseValue,
+ name, ref, path, parseValue, getValues,
 }) => {
-      const value = dot.pick(path, ref);
+      const value = getValues ? getValues(ref) : dot.pick(path, ref);
 
       data[name] = parseValue ? parseValue(value) : value;
     });
@@ -106,9 +106,8 @@ export default function Form({
     }
   }
 
-  function registerField(field: Field) {
-    if (!fields.find(f => f.name === field.name))
-      setFields(state => [...state, field]);
+  function registerField(field: UnformField) {
+    if (!fields.find(f => f.name === field.name)) setFields(state => [...state, field]);
   }
 
   function unregisterField(name: string) {
@@ -125,12 +124,7 @@ export default function Form({
         unregisterField,
       }}
     >
-      <form
-        data-testid="form"
-        style={style}
-        className={className}
-        onSubmit={handleSubmit}
-      >
+      <form data-testid="form" style={style} className={className} onSubmit={handleSubmit}>
         {children}
       </form>
     </FormContext.Provider>

--- a/lib/components/Choice.tsx
+++ b/lib/components/Choice.tsx
@@ -1,0 +1,77 @@
+import React, { Fragment, useEffect, useRef } from 'react';
+
+import useField from '../useField';
+
+interface Option {
+  id: string;
+  label?: string;
+}
+
+interface Props {
+  name: string;
+  options: Option[];
+  multiple?: boolean;
+}
+
+type ChoiceProps = JSX.IntrinsicElements['input'] & Props;
+
+export default function Choice({
+ name, options, multiple, ...rest
+}: ChoiceProps) {
+  const {
+ fieldName, registerField, defaultValue, error,
+} = useField(name);
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const localRefs = options.map(() => useRef<HTMLInputElement>(null));
+
+  const threatAsCheckbox = !!(multiple || options.length === 1);
+  const nativeField = threatAsCheckbox ? 'checkbox' : 'radio';
+
+  function getValues(refs: HTMLInputElement[]) {
+    const values = refs.filter(r => r.checked).map(f => f.value);
+    if (options.length === 1 || !threatAsCheckbox) return values[0] || undefined;
+    return values.length > 0 ? values : undefined;
+  }
+
+  function checked(id: string): boolean {
+    if (!defaultValue) return false;
+    if (typeof defaultValue === 'string') return [defaultValue].includes(id);
+    return Array.from(defaultValue).includes(id);
+  }
+
+  useEffect(() => {
+    const allRefs = localRefs.filter(r => r.current != null);
+    if (localRefs.length > 0 && localRefs.length === allRefs.length) {
+      registerField({
+        name: fieldName,
+        path: 'optional?',
+        ref: allRefs.map(r => r.current),
+        getValues,
+      });
+    }
+  }, [fieldName]);
+
+  return (
+    <Fragment>
+      {options.map(({ id, label }, idx) => {
+        const checkboxId = `${fieldName}-${id}`;
+        return (
+          <Fragment key={checkboxId}>
+            <input
+              {...rest}
+              ref={localRefs[idx]}
+              type={nativeField}
+              id={checkboxId}
+              name={fieldName}
+              aria-label={checkboxId}
+              value={id}
+              defaultChecked={checked(id)}
+            />
+            {label && <label htmlFor={checkboxId}>{label}</label>}
+          </Fragment>
+        );
+      })}
+      {error && <span>{error}</span>}
+    </Fragment>
+  );
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -15,6 +15,7 @@ export { default as Scope } from './Scope';
 export { default as Input } from './components/Input';
 export { default as Textarea } from './components/Textarea';
 export { default as Select } from './components/Select';
+export { default as Choice } from './components/Choice';
 
 /**
  * Types

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,8 @@
 export interface UnformField {
   name: string;
-  ref?: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
+  ref?: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | (HTMLInputElement | null)[];
   path: string;
+  getValues?: Function;
   parseValue?: Function;
   clearValue?: Function;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketseat/unform",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/unform/blob/master/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- Ensure you have added or ran the appropriate tests for your PR -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
* Implement multiple refs to a registerField method
* Add a Choice field that has support to multiple options (checkboxes)

Tries to resolve #20 

**Additional context**
For now, every registered field has a ref property. This property, refers a input field.
With chackboxes, we need to have multiple fields to represent options.
For that reason we need multiple refs too.
