### PR TITLE
chore: Fix prettier integration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,6 @@ module.exports = {
   extends: [
     'airbnb',
     'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
     'prettier/@typescript-eslint',
   ],
   rules: {

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ yarn add @rocketseat/unform
 Unform exposes two default form elements: `<Input />` and `<Select />`. Currently, `<Select />` element does not support multiple values, you can use [React Select](#react-select) example to achieve that.
 
 ```js
-import React from "react";
-import { Form, Input } from "@rocketseat/unform";
+import React from 'react';
+import { Form, Input } from '@rocketseat/unform';
 
 function App() {
   function handleSubmit(data) {
@@ -86,7 +86,7 @@ function App() {
     /**
      * {
      *   email: 'email@example.com',
-     *   password: "123456"
+     *   password: '123456'
      * }
      */
   };
@@ -111,8 +111,8 @@ Unform exposes two elements by default, Input and Select.
 Input elements can receive a `multiline` prop that will render a textarea instead.
 
 ```js
-import React from "react";
-import { Form, Input } from "@rocketseat/unform";
+import React from 'react';
+import { Form, Input } from '@rocketseat/unform';
 
 function App() {
   function handleSubmit(data) {};
@@ -131,13 +131,13 @@ function App() {
 #### Select element
 
 ```js
-import React from "react";
-import { Form, Select } from "@rocketseat/unform";
+import React from 'react';
+import { Form, Select } from '@rocketseat/unform';
 
 const options = [
-  { id: "react", title: "ReactJS" },
-  { id: "node", title: "NodeJS" },
-  { id: "rn", title: "React Native" }
+  { id: 'react', title: 'ReactJS' },
+  { id: 'node', title: 'NodeJS' },
+  { id: 'rn', title: 'React Native' }
 ];
 
 function App() {
@@ -156,8 +156,8 @@ function App() {
 ### Reset form
 
 ```js
-import React from "react";
-import { Form, Input } from "@rocketseat/unform";
+import React from 'react';
+import { Form, Input } from '@rocketseat/unform';
 
 function App() {
   function handleSubmit(data, { resetForm }) {
@@ -178,8 +178,8 @@ function App() {
 ### Nested fields
 
 ```js
-import React from "react";
-import { Form, Input, Scope } from "@rocketseat/unform";
+import React from 'react';
+import { Form, Input, Scope } from '@rocketseat/unform';
 
 function App() {
   function handleSubmit(data) {
@@ -213,8 +213,8 @@ function App() {
 _Optional_: Here you can set what the initial data for each field will be, you store the initial field values into a variable and load it in the `Form` using the prop `initialData`.
 
 ```js
-import React from "react";
-import { Form, Input, Scope } from "@rocketseat/unform";
+import React from 'react';
+import { Form, Input, Scope } from '@rocketseat/unform';
 
 function App() {
   const initialData = {
@@ -244,8 +244,8 @@ function App() {
 ### Validation
 
 ```js
-import React from "react";
-import { Form, Input } from "@rocketseat/unform";
+import React from 'react';
+import { Form, Input } from '@rocketseat/unform';
 import * as Yup from 'yup';
 
 const schema = Yup.object().shape({
@@ -272,8 +272,8 @@ function App() {
 ### Manipulate data
 
 ```js
-import React, { useState } from "react";
-import { Form, Input } from "@rocketseat/unform";
+import React, { useState } from 'react';
+import { Form, Input } from '@rocketseat/unform';
 import * as Yup from 'yup';
 
 const schema = Yup.object().shape({
@@ -330,10 +330,10 @@ Below are some examples with [react-select](https://github.com/JedWatson/react-s
 ### React select
 
 ```js
-import React, { useRef, useEffect } from "react";
-import Select from "react-select";
+import React, { useRef, useEffect } from 'react';
+import Select from 'react-select';
 
-import { useField } from "@rocketseat/unform";
+import { useField } from '@rocketseat/unform';
 
 export default function ReactSelect({
   name,
@@ -347,7 +347,7 @@ export default function ReactSelect({
 
   function parseSelectValue(selectValue) {
     if (!multiple) {
-      return selectValue ? selectValue.id : "";
+      return selectValue ? selectValue.id : '';
     }
 
     return selectValue ? selectValue.map(option => option.id) : [];
@@ -357,7 +357,7 @@ export default function ReactSelect({
     registerField({
       name: fieldName,
       ref: ref.current,
-      path: "state.value",
+      path: 'state.value',
       parseValue: parseSelectValue,
       clearValue: selectRef => {
         selectRef.select.clearValue();
@@ -400,12 +400,12 @@ export default function ReactSelect({
 ### React datepicker
 
 ```js
-import React, { useRef, useEffect, useState } from "react";
-import ReactDatePicker from "react-datepicker";
+import React, { useRef, useEffect, useState } from 'react';
+import ReactDatePicker from 'react-datepicker';
 
-import { useField } from "@rocketseat/unform";
+import { useField } from '@rocketseat/unform';
 
-import "react-datepicker/dist/react-datepicker.css";
+import 'react-datepicker/dist/react-datepicker.css';
 
 export default function DatePicker({ name }) {
   const ref = useRef(null);
@@ -416,7 +416,7 @@ export default function DatePicker({ name }) {
     registerField({
       name: fieldName,
       ref: ref.current,
-      path: "props.selected",
+      path: 'props.selected',
       clearValue: pickerRef => {
         pickerRef.clear();
       }

--- a/__tests__/Form.spec.tsx
+++ b/__tests__/Form.spec.tsx
@@ -1,110 +1,114 @@
-import React from "react";
-import "react-testing-library/cleanup-after-each";
-import "jest-dom/extend-expect";
-import { act, render, fireEvent, wait } from "react-testing-library";
-import * as Yup from "yup";
+import React from 'react';
+import 'react-testing-library/cleanup-after-each';
+import 'jest-dom/extend-expect';
+import {
+ act, render, fireEvent, wait,
+} from 'react-testing-library';
+import * as Yup from 'yup';
 
-import { Form, Input, Select, Scope } from "../lib";
-import CustomInputClear from "./utils/CustomInputClear";
-import CustomInputParse from "./utils/CustomInputParse";
+import {
+ Form, Input, Select, Scope,
+} from '../lib';
+import CustomInputClear from './utils/CustomInputClear';
+import CustomInputParse from './utils/CustomInputParse';
 
-describe("Form", () => {
-  it("should render form elements", () => {
+describe('Form', () => {
+  it('should render form elements', () => {
     const { container } = render(
       <Form onSubmit={jest.fn()}>
         <Input name="name" />
         <Input multiline name="bio" />
-        <Select name="tech" options={[{ id: "node", title: "Node" }]} />
-      </Form>
+        <Select name="tech" options={[{ id: 'node', title: 'Node' }]} />
+      </Form>,
     );
 
-    expect(!!container.querySelector("input[name=name]")).toBe(true);
-    expect(!!container.querySelector("textarea[name=bio]")).toBe(true);
-    expect(!!container.querySelector("select[name=tech]")).toBe(true);
+    expect(!!container.querySelector('input[name=name]')).toBe(true);
+    expect(!!container.querySelector('textarea[name=bio]')).toBe(true);
+    expect(!!container.querySelector('select[name=tech]')).toBe(true);
   });
 
-  it("should load initial data inside form elements", () => {
+  it('should load initial data inside form elements', () => {
     const { container } = render(
-      <Form onSubmit={jest.fn()} initialData={{ name: "Diego" }}>
+      <Form onSubmit={jest.fn()} initialData={{ name: 'Diego' }}>
         <Input name="name" />
-      </Form>
+      </Form>,
     );
 
-    expect(container.querySelector("input[name=name]")).toHaveAttribute(
-      "value",
-      "Diego"
+    expect(container.querySelector('input[name=name]')).toHaveAttribute(
+      'value',
+      'Diego',
     );
   });
 
-  it("should return form elements data on submit", () => {
+  it('should return form elements data on submit', () => {
     const submitMock = jest.fn();
 
     const { getByTestId, getByLabelText } = render(
       <Form
         onSubmit={submitMock}
-        initialData={{ address: { street: "John Doe Avenue" } }}
+        initialData={{ address: { street: 'John Doe Avenue' } }}
       >
         <Input name="name" />
         <Scope path="address">
           <Input name="street" />
         </Scope>
-      </Form>
+      </Form>,
     );
 
-    fireEvent.change(getByLabelText("name"), {
-      target: { value: "Diego" }
+    fireEvent.change(getByLabelText('name'), {
+      target: { value: 'Diego' },
     });
 
-    fireEvent.submit(getByTestId("form"));
+    fireEvent.submit(getByTestId('form'));
 
     expect(submitMock).toHaveBeenCalledWith(
       {
-        name: "Diego",
+        name: 'Diego',
         address: {
-          street: "John Doe Avenue"
-        }
+          street: 'John Doe Avenue',
+        },
       },
       {
-        resetForm: expect.any(Function)
-      }
+        resetForm: expect.any(Function),
+      },
     );
   });
 
-  it("should remove unmounted elements from refs", () => {
+  it('should remove unmounted elements from refs', () => {
     const submitMock = jest.fn();
 
     const { getByTestId, rerender } = render(
-      <Form onSubmit={submitMock} initialData={{ name: "Diego" }}>
+      <Form onSubmit={submitMock} initialData={{ name: 'Diego' }}>
         <Input name="name" />
-      </Form>
+      </Form>,
     );
 
     rerender(
-      <Form onSubmit={submitMock} initialData={{ another: "Diego" }}>
+      <Form onSubmit={submitMock} initialData={{ another: 'Diego' }}>
         <Input name="another" />
-      </Form>
+      </Form>,
     );
 
-    fireEvent.submit(getByTestId("form"));
+    fireEvent.submit(getByTestId('form'));
 
     expect(submitMock).toHaveBeenCalledWith(
       {
-        another: "Diego"
+        another: 'Diego',
       },
       {
-        resetForm: expect.any(Function)
-      }
+        resetForm: expect.any(Function),
+      },
     );
   });
 
-  it("should update data to match schema", async () => {
+  it('should update data to match schema', async () => {
     const submitMock = jest.fn();
     const schema = Yup.object().shape({
       name: Yup.string(),
-      bio: Yup.string().when("$stripBio", {
+      bio: Yup.string().when('$stripBio', {
         is: true,
-        then: Yup.string().strip(true)
-      })
+        then: Yup.string().strip(true),
+      }),
     });
 
     const { getByTestId } = render(
@@ -112,78 +116,78 @@ describe("Form", () => {
         schema={schema}
         context={{ stripBio: true }}
         onSubmit={submitMock}
-        initialData={{ name: "Diego", bio: "Testing" }}
+        initialData={{ name: 'Diego', bio: 'Testing' }}
       >
         <Input name="name" />
         <Input name="bio" />
-      </Form>
+      </Form>,
     );
 
     act(() => {
-      fireEvent.submit(getByTestId("form"));
+      fireEvent.submit(getByTestId('form'));
     });
 
     await wait(() => {
       expect(submitMock).toHaveBeenCalledWith(
-        { name: "Diego" },
+        { name: 'Diego' },
         {
-          resetForm: expect.any(Function)
-        }
+          resetForm: expect.any(Function),
+        },
       );
     });
   });
 
-  it("should reset form data when resetForm helper is dispatched", () => {
+  it('should reset form data when resetForm helper is dispatched', () => {
     const { getByTestId, getByLabelText } = render(
       <Form onSubmit={(_, { resetForm }) => resetForm()}>
         <Input name="name" />
-        <Select name="tech" options={[{ id: "node", title: "NodeJS" }]} />
-      </Form>
+        <Select name="tech" options={[{ id: 'node', title: 'NodeJS' }]} />
+      </Form>,
     );
 
-    getByLabelText("name").setAttribute("value", "Diego");
+    getByLabelText('name').setAttribute('value', 'Diego');
 
-    fireEvent.change(getByLabelText("tech"), { target: { value: "node" } });
+    fireEvent.change(getByLabelText('tech'), { target: { value: 'node' } });
 
-    fireEvent.submit(getByTestId("form"));
+    fireEvent.submit(getByTestId('form'));
 
-    expect((getByLabelText("name") as HTMLInputElement).value).toBe("");
-    expect((getByLabelText("tech") as HTMLSelectElement).value).toBe("");
+    expect((getByLabelText('name') as HTMLInputElement).value).toBe('');
+    expect((getByLabelText('tech') as HTMLSelectElement).value).toBe('');
   });
 
-  it("should be able to have custom value parser", () => {
+  it('should be able to have custom value parser', () => {
     const submitMock = jest.fn();
 
     const { getByTestId } = render(
-      <Form onSubmit={submitMock} initialData={{ name: "Diego" }}>
+      <Form onSubmit={submitMock} initialData={{ name: 'Diego' }}>
         <CustomInputParse name="name" />
-      </Form>
+      </Form>,
     );
 
-    fireEvent.submit(getByTestId("form"));
+    fireEvent.submit(getByTestId('form'));
 
     expect(submitMock).toHaveBeenCalledWith(
       {
-        name: "Diego-test"
+        name: 'Diego-test',
       },
       {
-        resetForm: expect.any(Function)
-      }
+        resetForm: expect.any(Function),
+      },
     );
   });
 
-  it("should be able to have custom value clearer", () => {
+  it('should be able to have custom value clearer', () => {
     const { getByTestId, getByLabelText } = render(
       <Form
         onSubmit={(_, { resetForm }) => resetForm()}
-        initialData={{ name: "Diego" }}
+        initialData={{ name: 'Diego' }}
       >
         <CustomInputClear name="name" />
-      </Form>
+      </Form>,
     );
 
-    fireEvent.submit(getByTestId("form"));
+    fireEvent.submit(getByTestId('form'));
 
-    expect((getByLabelText("name") as HTMLInputElement).value).toBe("test");
+    expect((getByLabelText('name') as HTMLInputElement).value).toBe('test');
   });
 });

--- a/__tests__/Scope.spec.tsx
+++ b/__tests__/Scope.spec.tsx
@@ -1,24 +1,24 @@
-import React from "react";
-import "react-testing-library/cleanup-after-each";
-import "jest-dom/extend-expect";
-import { render } from "react-testing-library";
+import React from 'react';
+import 'react-testing-library/cleanup-after-each';
+import 'jest-dom/extend-expect';
+import { render } from 'react-testing-library';
 
-import { Form, Scope, Input } from "../lib";
+import { Form, Scope, Input } from '../lib';
 
-describe("Form", () => {
-  it("should name form elements based on scope", () => {
+describe('Form', () => {
+  it('should name form elements based on scope', () => {
     const { container } = render(
       <Form onSubmit={jest.fn()}>
         <Scope path="profile">
           <Input name="name" />
         </Scope>
-      </Form>
+      </Form>,
     );
 
     expect(!!container.querySelector("input[name='profile.name']")).toBe(true);
   });
 
-  it("should concat scope paths", () => {
+  it('should concat scope paths', () => {
     const { container } = render(
       <Form onSubmit={jest.fn()}>
         <Scope path="profile">
@@ -26,11 +26,11 @@ describe("Form", () => {
             <Input name="name" />
           </Scope>
         </Scope>
-      </Form>
+      </Form>,
     );
 
     expect(!!container.querySelector("input[name='profile.user.name']")).toBe(
-      true
+      true,
     );
   });
 });

--- a/__tests__/components/Input.spec.tsx
+++ b/__tests__/components/Input.spec.tsx
@@ -1,49 +1,51 @@
-import React from "react";
-import "react-testing-library/cleanup-after-each";
-import "jest-dom/extend-expect";
-import { act, render, fireEvent, wait } from "react-testing-library";
-import * as Yup from "yup";
+import React from 'react';
+import 'react-testing-library/cleanup-after-each';
+import 'jest-dom/extend-expect';
+import {
+ act, render, fireEvent, wait,
+} from 'react-testing-library';
+import * as Yup from 'yup';
 
-import { Form, Input } from "../../lib";
+import { Form, Input } from '../../lib';
 
-describe("Form", () => {
-  it("should display label", () => {
+describe('Form', () => {
+  it('should display label', () => {
     const { getByText } = render(
       <Form onSubmit={jest.fn()}>
         <Input name="name" label="Name" />
-      </Form>
+      </Form>,
     );
 
-    expect(!!getByText("Name")).toBe(true);
+    expect(!!getByText('Name')).toBe(true);
   });
 
-  it("should display error", async () => {
+  it('should display error', async () => {
     const schema = Yup.object().shape({
-      name: Yup.string().required("Name is required")
+      name: Yup.string().required('Name is required'),
     });
 
     const { getByText, getByTestId } = render(
       <Form schema={schema} onSubmit={jest.fn()}>
         <Input name="name" label="Nome" />
-      </Form>
+      </Form>,
     );
 
     act(() => {
-      fireEvent.submit(getByTestId("form"));
+      fireEvent.submit(getByTestId('form'));
     });
 
-    await wait(() => expect(!!getByText("Name is required")).toBe(true));
+    await wait(() => expect(!!getByText('Name is required')).toBe(true));
   });
 
-  it("should act as textarea when multiline prop is supplied", () => {
+  it('should act as textarea when multiline prop is supplied', () => {
     const { container } = render(
       <Form onSubmit={jest.fn()}>
         <Input name="name" label="Name" />
         <Input name="profile" label="Profile" multiline />
-      </Form>
+      </Form>,
     );
 
-    expect(!!container.querySelector("input[name=name]")).toBe(true);
-    expect(!!container.querySelector("textarea[name=profile]")).toBe(true);
+    expect(!!container.querySelector('input[name=name]')).toBe(true);
+    expect(!!container.querySelector('textarea[name=profile]')).toBe(true);
   });
 });

--- a/__tests__/components/Select.spec.tsx
+++ b/__tests__/components/Select.spec.tsx
@@ -1,77 +1,79 @@
-import React from "react";
-import "react-testing-library/cleanup-after-each";
-import "jest-dom/extend-expect";
-import { act, render, fireEvent, wait } from "react-testing-library";
-import * as Yup from "yup";
+import React from 'react';
+import 'react-testing-library/cleanup-after-each';
+import 'jest-dom/extend-expect';
+import {
+ act, render, fireEvent, wait,
+} from 'react-testing-library';
+import * as Yup from 'yup';
 
-import { Form, Select } from "../../lib";
+import { Form, Select } from '../../lib';
 
-describe("Form", () => {
-  it("should display label", () => {
+describe('Form', () => {
+  it('should display label', () => {
     const { getByText } = render(
       <Form onSubmit={jest.fn()}>
         <Select
-          options={[{ id: "node", title: "NodeJS" }]}
+          options={[{ id: 'node', title: 'NodeJS' }]}
           name="tech"
           label="Tech"
         />
-      </Form>
+      </Form>,
     );
 
-    expect(!!getByText("Tech")).toBe(true);
+    expect(!!getByText('Tech')).toBe(true);
   });
 
-  it("should display error", async () => {
+  it('should display error', async () => {
     const schema = Yup.object().shape({
-      tech: Yup.string().required("Tech is required")
+      tech: Yup.string().required('Tech is required'),
     });
 
     const { getByText, getByTestId } = render(
       <Form schema={schema} onSubmit={jest.fn()}>
         <Select
-          options={[{ id: "node", title: "NodeJS" }]}
+          options={[{ id: 'node', title: 'NodeJS' }]}
           name="tech"
           label="Tech"
         />
-      </Form>
+      </Form>,
     );
 
     act(() => {
-      fireEvent.submit(getByTestId("form"));
+      fireEvent.submit(getByTestId('form'));
     });
 
-    await wait(() => expect(!!getByText("Tech is required")).toBe(true));
+    await wait(() => expect(!!getByText('Tech is required')).toBe(true));
   });
 
-  it("should return correct selected value", () => {
+  it('should return correct selected value', () => {
     const submitMock = jest.fn();
 
     const { getByTestId, getByLabelText } = render(
       <Form onSubmit={submitMock}>
         <Select
           options={[
-            { id: "node", title: "NodeJS" },
-            { id: "react", title: "ReactJS" }
+            { id: 'node', title: 'NodeJS' },
+            { id: 'react', title: 'ReactJS' },
           ]}
           name="tech"
           label="Tech"
         />
-      </Form>
+      </Form>,
     );
 
     act(() => {
-      fireEvent.change(getByLabelText("tech"), { target: { value: "react" } });
+      fireEvent.change(getByLabelText('tech'), { target: { value: 'react' } });
     });
 
-    fireEvent.submit(getByTestId("form"));
+    fireEvent.submit(getByTestId('form'));
 
     expect(submitMock).toHaveBeenCalledWith(
       {
-        tech: "react"
+        tech: 'react',
       },
       {
-        resetForm: expect.any(Function)
-      }
+        resetForm: expect.any(Function),
+      },
     );
   });
 

--- a/__tests__/utils/CustomInputClear.tsx
+++ b/__tests__/utils/CustomInputClear.tsx
@@ -1,6 +1,6 @@
-import React, { InputHTMLAttributes, useEffect, useRef } from "react";
+import React, { InputHTMLAttributes, useEffect, useRef } from 'react';
 
-import { useField } from "../../lib";
+import { useField } from '../../lib';
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   name: string;
@@ -9,17 +9,19 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
 
 export default function Input({ name, label, ...rest }: Props) {
   const ref = useRef<HTMLInputElement>(null);
-  const { fieldName, registerField, defaultValue, error } = useField(name);
+  const {
+ fieldName, registerField, defaultValue, error,
+} = useField(name);
 
   useEffect(() => {
     if (ref.current) {
       registerField({
         name: fieldName,
         ref: ref.current,
-        path: "value",
+        path: 'value',
         clearValue: (inputRef: HTMLInputElement) => {
-          inputRef.value = "test";
-        }
+          inputRef.value = 'test';
+        },
       });
     }
   }, [ref.current, fieldName]);

--- a/__tests__/utils/CustomInputParse.tsx
+++ b/__tests__/utils/CustomInputParse.tsx
@@ -1,6 +1,6 @@
-import React, { InputHTMLAttributes, useEffect, useRef } from "react";
+import React, { InputHTMLAttributes, useEffect, useRef } from 'react';
 
-import { useField } from "../../lib";
+import { useField } from '../../lib';
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   name: string;
@@ -9,15 +9,17 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
 
 export default function Input({ name, label, ...rest }: Props) {
   const ref = useRef<HTMLInputElement>(null);
-  const { fieldName, registerField, defaultValue, error } = useField(name);
+  const {
+ fieldName, registerField, defaultValue, error,
+} = useField(name);
 
   useEffect(() => {
     if (ref.current) {
       registerField({
         name: fieldName,
         ref: ref.current,
-        path: "value",
-        parseValue: (value: string) => value.concat("-test")
+        path: 'value',
+        parseValue: (value: string) => value.concat('-test'),
       });
     }
   }, [ref.current, fieldName]);

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ["rocketseat"]
+  extends: ['rocketseat'],
 };

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,9 +1,12 @@
-import React, { useState } from "react";
-import { hot } from "react-hot-loader/root";
-import * as Yup from "yup";
-import { Form, Input, Select, Scope, SubmitHandler } from "../../lib";
-import DatePicker from "./components/DatePicker";
-import ReactSelect from "./components/ReactSelect";
+import React, { useState } from 'react';
+import { hot } from 'react-hot-loader/root';
+import * as Yup from 'yup';
+
+import {
+ Form, Input, Select, Scope, SubmitHandler,
+} from '../../lib';
+import DatePicker from './components/DatePicker';
+import ReactSelect from './components/ReactSelect';
 
 const schema = Yup.object().shape({
   name: Yup.string().required(),
@@ -15,16 +18,16 @@ const schema = Yup.object().shape({
     .required(),
   billingAddress: Yup.object().shape({
     street: Yup.string().required(),
-    number: Yup.string().required()
+    number: Yup.string().required(),
   }),
-  shippingAddress: Yup.object().when("$useShippingAsBilling", {
+  shippingAddress: Yup.object().when('$useShippingAsBilling', {
     is: false,
     then: Yup.object().shape({
       street: Yup.string().required(),
-      number: Yup.string().required()
+      number: Yup.string().required(),
     }),
-    otherwise: Yup.object().strip(true)
-  })
+    otherwise: Yup.object().strip(true),
+  }),
 });
 
 interface Data {
@@ -40,18 +43,18 @@ interface Data {
 
 function App() {
   const [useShippingAsBilling, setUseShippingAsBilling] = useState<boolean>(
-    true
+    true,
   );
 
   const [formData] = useState<Data>({
-    name: "Diego",
-    profile: "CTO na Rocketseat",
-    tech: "node",
-    people: ["1", "3"],
+    name: 'Diego',
+    profile: 'CTO na Rocketseat',
+    tech: 'node',
+    people: ['1', '3'],
     date: new Date(),
     billingAddress: {
-      number: 833
-    }
+      number: 833,
+    },
   });
 
   const handleSubmit: SubmitHandler<Data> = (data, { resetForm }) => {
@@ -73,9 +76,9 @@ function App() {
       <ReactSelect
         name="tech"
         options={[
-          { id: "react", title: "ReactJS" },
-          { id: "node", title: "NodeJS" },
-          { id: "rn", title: "React Native" }
+          { id: 'react', title: 'ReactJS' },
+          { id: 'node', title: 'NodeJS' },
+          { id: 'rn', title: 'React Native' },
         ]}
       />
 
@@ -83,9 +86,9 @@ function App() {
         name="people"
         multiple
         options={[
-          { id: "1", title: "Diego" },
-          { id: "2", title: "João" },
-          { id: "3", title: "Higo" }
+          { id: '1', title: 'Diego' },
+          { id: '2', title: 'João' },
+          { id: '3', title: 'Higo' },
         ]}
       />
 

--- a/example/src/components/DatePicker.tsx
+++ b/example/src/components/DatePicker.tsx
@@ -1,23 +1,25 @@
-import React, { useRef, useEffect, useState } from "react";
-import DatePicker from "react-datepicker";
+import React, { useRef, useEffect, useState } from 'react';
+import DatePicker from 'react-datepicker';
 
-import { useField } from "../../../lib";
+import { useField } from '../../../lib';
 
-import "react-datepicker/dist/react-datepicker.css";
+import 'react-datepicker/dist/react-datepicker.css';
 
 export default function ReactDatePicker({ name }) {
   const ref = useRef(null);
-  const { fieldName, registerField, defaultValue, error } = useField(name);
+  const {
+ fieldName, registerField, defaultValue, error,
+} = useField(name);
   const [selected, setSelected] = useState(defaultValue);
 
   useEffect(() => {
     registerField({
       name: fieldName,
       ref: ref.current,
-      path: "props.selected",
-      clearValue: pickerRef => {
+      path: 'props.selected',
+      clearValue: (pickerRef) => {
         pickerRef.clear();
-      }
+      },
     });
   }, [ref.current, fieldName]);
 

--- a/example/src/components/ReactSelect.tsx
+++ b/example/src/components/ReactSelect.tsx
@@ -1,7 +1,7 @@
-import React, { useRef, useEffect } from "react";
-import Select from "react-select";
+import React, { useRef, useEffect } from 'react';
+import Select from 'react-select';
 
-import { useField } from "../../../lib";
+import { useField } from '../../../lib';
 
 interface Option {
   id: string;
@@ -23,11 +23,13 @@ export default function ReactSelect({
   ...rest
 }: Props) {
   const ref = useRef(null);
-  const { fieldName, registerField, defaultValue, error } = useField(name);
+  const {
+ fieldName, registerField, defaultValue, error,
+} = useField(name);
 
   function parseSelectValue(selectValue) {
     if (!multiple) {
-      return selectValue ? selectValue.id : "";
+      return selectValue ? selectValue.id : '';
     }
 
     return selectValue ? selectValue.map(option => option.id) : [];
@@ -37,11 +39,11 @@ export default function ReactSelect({
     registerField({
       name: fieldName,
       ref: ref.current,
-      path: "state.value",
+      path: 'state.value',
       parseValue: parseSelectValue,
-      clearValue: selectRef => {
+      clearValue: (selectRef) => {
         selectRef.select.clearValue();
-      }
+      },
     });
   }, [ref.current, fieldName]);
 

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import ReactDOM from "react-dom";
+import React from 'react';
+import ReactDOM from 'react-dom';
 
-import App from "./App";
+import App from './App';
 
-ReactDOM.render(<App />, document.getElementById("app"));
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,26 +1,26 @@
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
-const { resolve } = require("path");
+const { resolve } = require('path');
 
 module.exports = {
   bail: true,
   clearMocks: true,
   collectCoverage: true,
-  collectCoverageFrom: ["lib/**/*.{ts,tsx}"],
-  coverageDirectory: "__tests__/coverage",
-  coverageReporters: ["json", "lcov"],
+  collectCoverageFrom: ['lib/**/*.{ts,tsx}'],
+  coverageDirectory: '__tests__/coverage',
+  coverageReporters: ['json', 'lcov'],
   coverageThreshold: {
     global: {
       branches: 80,
       functions: 80,
       lines: 80,
-      statements: 80
-    }
+      statements: 80,
+    },
   },
-  testMatch: ["**/__tests__/**/*.spec.+(ts|tsx|js)"],
+  testMatch: ['**/__tests__/**/*.spec.+(ts|tsx|js)'],
   transform: {
-    "^.+\\.(ts|tsx)$": "ts-jest"
+    '^.+\\.(ts|tsx)$': 'ts-jest',
   },
-  moduleFileExtensions: ["ts", "tsx", "js", "jsx"]
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
 };

--- a/lib/Context.tsx
+++ b/lib/Context.tsx
@@ -1,13 +1,13 @@
 /* istanbul ignore file */
 
-import { createContext } from "react";
+import { createContext } from 'react';
 
-import { Context } from "./types";
+import { Context } from './types';
 
 export default createContext<Context>({
   initialData: {},
   errors: {},
-  scopePath: "",
+  scopePath: '',
   registerField: () => {},
-  unregisterField: () => {}
+  unregisterField: () => {},
 });

--- a/lib/Form.tsx
+++ b/lib/Form.tsx
@@ -1,9 +1,9 @@
-import dot from "dot-object";
-import React, { FormEvent, useState } from "react";
-import { ObjectSchema, ValidationError } from "yup";
+import dot from 'dot-object';
+import React, { FormEvent, useState } from 'react';
+import { ObjectSchema, ValidationError } from 'yup';
 
-import FormContext from "./Context";
-import { Field, Errors } from "./types";
+import FormContext from './Context';
+import { Field, Errors } from './types';
 
 interface Context {
   [key: string]: any;
@@ -34,7 +34,7 @@ export default function Form({
   children,
   schema,
   context = {},
-  onSubmit
+  onSubmit,
 }: Props) {
   const [errors, setErrors] = useState<Errors>({});
   const [fields, setFields] = useState<Field[]>([]);
@@ -42,7 +42,9 @@ export default function Form({
   function parseFormData() {
     const data = {};
 
-    fields.forEach(({ name, ref, path, parseValue }) => {
+    fields.forEach(({
+ name, ref, path, parseValue,
+}) => {
       const value = dot.pick(path, ref);
 
       data[name] = parseValue ? parseValue(value) : value;
@@ -59,7 +61,7 @@ export default function Form({
         return clearValue(ref);
       }
 
-      return dot.set(path, "", ref as object);
+      return dot.set(path, '', ref as object);
     });
   }
 
@@ -73,12 +75,12 @@ export default function Form({
         await schema.validate(data, {
           abortEarly: false,
           stripUnknown: true,
-          context
+          context,
         });
 
         data = schema.cast(data, {
           stripUnknown: true,
-          context
+          context,
         });
       }
 
@@ -113,9 +115,9 @@ export default function Form({
       value={{
         initialData,
         errors,
-        scopePath: "",
+        scopePath: '',
         registerField,
-        unregisterField
+        unregisterField,
       }}
     >
       <form data-testid="form" onSubmit={handleSubmit}>

--- a/lib/Scope.tsx
+++ b/lib/Scope.tsx
@@ -1,6 +1,6 @@
-import React, { useContext, ReactNode } from "react";
+import React, { useContext, ReactNode } from 'react';
 
-import FormContext from "./Context";
+import FormContext from './Context';
 
 interface Props {
   path: string;
@@ -14,7 +14,7 @@ export default function Scope({ path, children }: Props) {
     <FormContext.Provider
       value={{
         ...form,
-        scopePath: scopePath.concat(scopePath ? `.${path}` : path)
+        scopePath: scopePath.concat(scopePath ? `.${path}` : path),
       }}
     >
       {children}

--- a/lib/components/Input.tsx
+++ b/lib/components/Input.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef } from 'react';
 
-import useField from "../useField";
+import useField from '../useField';
 
 interface Props<T> {
   name: string;
@@ -8,8 +8,8 @@ interface Props<T> {
   multiline?: T;
 }
 
-type InputProps = JSX.IntrinsicElements["input"] & Props<true>;
-type TextAreaProps = JSX.IntrinsicElements["textarea"] & Props<false>;
+type InputProps = JSX.IntrinsicElements['input'] & Props<true>;
+type TextAreaProps = JSX.IntrinsicElements['textarea'] & Props<false>;
 
 export default function Input({
   name,
@@ -18,11 +18,13 @@ export default function Input({
   ...rest
 }: InputProps | TextAreaProps) {
   const ref = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
-  const { fieldName, registerField, defaultValue, error } = useField(name);
+  const {
+ fieldName, registerField, defaultValue, error,
+} = useField(name);
 
   useEffect(() => {
     if (ref.current) {
-      registerField({ name: fieldName, ref: ref.current, path: "value" });
+      registerField({ name: fieldName, ref: ref.current, path: 'value' });
     }
   }, [ref.current, fieldName]);
 
@@ -31,8 +33,8 @@ export default function Input({
     ref,
     id: fieldName,
     name: fieldName,
-    "aria-label": fieldName,
-    defaultValue
+    'aria-label': fieldName,
+    defaultValue,
   };
 
   return (

--- a/lib/components/Select.tsx
+++ b/lib/components/Select.tsx
@@ -1,6 +1,6 @@
-import React, { SelectHTMLAttributes, useEffect, useRef } from "react";
+import React, { SelectHTMLAttributes, useEffect, useRef } from 'react';
 
-import useField from "../useField";
+import useField from '../useField';
 
 interface Option {
   id: string;
@@ -13,13 +13,17 @@ interface Props extends SelectHTMLAttributes<HTMLSelectElement> {
   options: Option[];
 }
 
-export default function Select({ name, label, options, ...rest }: Props) {
+export default function Select({
+ name, label, options, ...rest
+}: Props) {
   const ref = useRef<HTMLSelectElement>(null);
-  const { fieldName, registerField, defaultValue, error } = useField(name);
+  const {
+ fieldName, registerField, defaultValue, error,
+} = useField(name);
 
   useEffect(() => {
     if (ref.current) {
-      registerField({ name: fieldName, ref: ref.current, path: "value" });
+      registerField({ name: fieldName, ref: ref.current, path: 'value' });
     }
   }, [ref.current, fieldName]);
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,21 +1,21 @@
 /**
  * Hooks
  */
-export { default as useField } from "./useField";
+export { default as useField } from './useField';
 
 /**
  * Main components
  */
-export { default as Form } from "./Form";
-export { default as Scope } from "./Scope";
+export { default as Form } from './Form';
+export { default as Scope } from './Scope';
 
 /**
  * Form components
  */
-export { default as Input } from "./components/Input";
-export { default as Select } from "./components/Select";
+export { default as Input } from './components/Input';
+export { default as Select } from './components/Select';
 
 /**
  * Types
  */
-export { SubmitHandler } from "./Form";
+export { SubmitHandler } from './Form';

--- a/lib/useField.ts
+++ b/lib/useField.ts
@@ -1,7 +1,7 @@
-import dot from "dot-object";
-import { useContext, useEffect } from "react";
+import dot from 'dot-object';
+import { useContext, useEffect } from 'react';
 
-import FormContext from "./Context";
+import FormContext from './Context';
 
 export default function useField(name: string) {
   const {
@@ -9,14 +9,12 @@ export default function useField(name: string) {
     errors,
     scopePath,
     unregisterField,
-    registerField
+    registerField,
   } = useContext(FormContext);
 
   const fieldName = scopePath ? `${scopePath}.${name}` : name;
 
-  useEffect(() => {
-    return () => unregisterField(fieldName);
-  }, [fieldName]);
+  useEffect(() => () => unregisterField(fieldName), [fieldName]);
 
   const defaultValue = dot.pick(fieldName, initialData);
   const error = errors[fieldName];
@@ -25,6 +23,6 @@ export default function useField(name: string) {
     fieldName,
     registerField,
     defaultValue,
-    error
+    error,
   };
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,42 +1,42 @@
-import babel from "rollup-plugin-babel";
-import commonjs from "rollup-plugin-commonjs";
-import resolve from "rollup-plugin-node-resolve";
-import external from "rollup-plugin-peer-deps-external";
-import { terser } from "rollup-plugin-terser";
-import typescript from "rollup-plugin-typescript2";
-import url from "rollup-plugin-url";
+import babel from 'rollup-plugin-babel';
+import commonjs from 'rollup-plugin-commonjs';
+import resolve from 'rollup-plugin-node-resolve';
+import external from 'rollup-plugin-peer-deps-external';
+import { terser } from 'rollup-plugin-terser';
+import typescript from 'rollup-plugin-typescript2';
+import url from 'rollup-plugin-url';
 
-import pkg from "./package.json";
+import pkg from './package.json';
 
 export default {
-  input: "lib/index.ts",
-  external: ["react", "react-dom", "yup"],
+  input: 'lib/index.ts',
+  external: ['react', 'react-dom', 'yup'],
   output: [
     {
       file: pkg.main,
-      format: "cjs",
-      sourcemap: true
+      format: 'cjs',
+      sourcemap: true,
     },
     {
       file: pkg.module,
-      format: "es",
-      sourcemap: true
-    }
+      format: 'es',
+      sourcemap: true,
+    },
   ],
   plugins: [
     external({
-      includeDependencies: false
+      includeDependencies: false,
     }),
     url(),
     resolve(),
     babel({
-      exclude: "node_modules/**"
+      exclude: 'node_modules/**',
     }),
     typescript({
       rollupCommonJSResolveHack: true,
-      clean: true
+      clean: true,
     }),
     commonjs(),
-    terser()
-  ]
+    terser(),
+  ],
 };


### PR DESCRIPTION
**Changes proposed**

Remove Prettier recommended rules from ESLint.

**Additional context**

Prettier recommended settings were overriding some of AirBnB style guide rules.

Example: AirBnB points that quotes must be single, and with Prettier recommended rules we are using double quotes.
