### PR TITLE
chore: Restore textarea component

### DIFF
--- a/__tests__/components/Textarea.spec.tsx
+++ b/__tests__/components/Textarea.spec.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import 'react-testing-library/cleanup-after-each';
+import 'jest-dom/extend-expect';
+import {
+ act, render, fireEvent, wait,
+} from 'react-testing-library';
+import * as Yup from 'yup';
+
+import { Form, Textarea } from '../../lib';
+
+describe('Form', () => {
+  it('should display label', () => {
+    const { getByText } = render(
+      <Form onSubmit={jest.fn()}>
+        <Textarea name="name" label="Name" />
+      </Form>,
+    );
+
+    expect(!!getByText('Name')).toBe(true);
+  });
+
+  it('should display error', async () => {
+    const schema = Yup.object().shape({
+      name: Yup.string().required('Name is required'),
+    });
+
+    const { getByText, getByTestId } = render(
+      <Form schema={schema} onSubmit={jest.fn()}>
+        <Textarea name="name" label="Nome" />
+      </Form>,
+    );
+
+    act(() => {
+      fireEvent.submit(getByTestId('form'));
+    });
+
+    await wait(() => expect(!!getByText('Name is required')).toBe(true));
+  });
+});

--- a/lib/components/Input.tsx
+++ b/lib/components/Input.tsx
@@ -8,8 +8,8 @@ interface Props<T> {
   multiline?: T;
 }
 
-type InputProps = JSX.IntrinsicElements['input'] & Props<true>;
-type TextAreaProps = JSX.IntrinsicElements['textarea'] & Props<false>;
+type InputProps = JSX.IntrinsicElements['input'] & Props<false>;
+type TextAreaProps = JSX.IntrinsicElements['textarea'] & Props<true>;
 
 export default function Input({
   name,

--- a/lib/components/Textarea.tsx
+++ b/lib/components/Textarea.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect } from 'react';
+
+import Input from './Input';
+
+interface Props {
+  name: string;
+  label?: string;
+  multiline?: true;
+}
+
+type TextAreaProps = JSX.IntrinsicElements['textarea'] & Props;
+
+export default function Textarea(props: TextAreaProps) {
+  useEffect(() => {
+    console.warn(
+      'Textarea will be deprecated in the next unform release. Please use <Input multiline /> instead',
+    );
+  }, []);
+
+  return <Input {...props} multiline />;
+}

--- a/lib/components/Textarea.tsx
+++ b/lib/components/Textarea.tsx
@@ -13,7 +13,7 @@ type TextAreaProps = JSX.IntrinsicElements['textarea'] & Props;
 export default function Textarea(props: TextAreaProps) {
   useEffect(() => {
     console.warn(
-      'Textarea will be deprecated in the next unform release. Please use <Input multiline /> instead',
+      'Textarea will be deprecated in the next major unform release. Please use <Input multiline /> instead',
     );
   }, []);
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,6 +13,7 @@ export { default as Scope } from './Scope';
  * Form components
  */
 export { default as Input } from './components/Input';
+export { default as Textarea } from './components/Textarea';
 export { default as Select } from './components/Select';
 
 /**


### PR DESCRIPTION
**Changes proposed**
`<Textarea />` was removed in #60, but it was all of a sudden. This PR restores the component but internally it renders a `<Input multiline />` which is the new way of doing it.

It also puts up a `console.warn` for the user to know that `<Textarea />` component will be deprecated in a future version of Unform.

Closes #74 

**Additional context**
<!-- Add any other context or screenshots about the feature request here. -->
