### PR TITLE
feat: Add file input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Unform is a performance focused library that helps you creating beautiful forms 
   - [Elements](#elements)
     - [Input element](#input-element)
     - [Select element](#select-element)
+    - [File Input element](#file-input-element)
   - [Reset Form](#reset-form)
   - [Nested fields](#nested-fields)
   - [Initial data](#initial-data)
@@ -150,6 +151,29 @@ function App() {
   return (
     <Form onSubmit={handleSubmit}>
       <Select name="tech" options={options} />
+
+      <button type="submit">Send</button>
+    </Form>
+  );
+}
+```
+
+#### File Input element
+
+FileInput components may receive an `onStartProgress` property that will be called when file loading starts.
+
+```js
+import React from 'react';
+import { Form, FileInput } from '@rocketseat/unform';
+
+function App() {
+  function handleSubmit(data) {}
+
+  function handleProgress(progress, event) {}
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <FileInput name="attach" onStartProgress={handleProgress} />
 
       <button type="submit">Send</button>
     </Form>

--- a/__tests__/components/FileInput.spec.tsx
+++ b/__tests__/components/FileInput.spec.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import 'react-testing-library/cleanup-after-each';
+import 'jest-dom/extend-expect';
+import {
+  act, render, fireEvent, wait,
+} from 'react-testing-library';
+import * as Yup from 'yup';
+
+import { Form, FileInput } from '../../lib';
+
+describe('Form', () => {
+  it('should render file input', () => {
+    const { container } = render(
+      <Form onSubmit={jest.fn()}>
+        <FileInput name="name" label="Name" />
+      </Form>,
+    );
+
+    expect(!!container.querySelector('input[type=file]')).toBe(true);
+  });
+
+  it('should display label', () => {
+    const { getByText } = render(
+      <Form onSubmit={jest.fn()}>
+        <FileInput name="attach" label="Attachment" />
+      </Form>,
+    );
+
+    expect(!!getByText('Attachment')).toBe(true);
+  });
+
+  it('should display error', async () => {
+    const schema = Yup.object().shape({
+      attach: Yup.string().required('File is required'),
+    });
+
+    const { getByText, getByTestId } = render(
+      <Form schema={schema} onSubmit={jest.fn()}>
+        <FileInput name="attach" label="Attachment" />
+      </Form>,
+    );
+
+    act(() => {
+      fireEvent.submit(getByTestId('form'));
+    });
+
+    await wait(() => expect(!!getByText('File is required')).toBe(true));
+  });
+
+  it('should call onStartProgress when exists into properties', async () => {
+    const onStartProgressMock = jest.fn();
+
+    const { getByLabelText } = render(
+      <Form onSubmit={jest.fn()}>
+        <FileInput name="attach" onStartProgress={onStartProgressMock} />
+      </Form>,
+    );
+
+    const file = new Blob(['file contents'], { type: 'text/plain' });
+
+    act(() => {
+      fireEvent.change(getByLabelText('attach'), {
+        target: { files: [file] },
+      });
+    });
+
+    await wait(() => {
+      expect(onStartProgressMock).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.any(ProgressEvent)
+      );
+    });
+  });
+
+  it('should reset file input when resetFrom dispatched', async () => {
+    const { getByTestId, getByLabelText } = render(
+      <Form onSubmit={(_, { resetForm }) => resetForm()}>
+        <FileInput name="attach" />
+      </Form>,
+    );
+
+    const file = new Blob(['file contents'], { type: 'text/plain' });
+
+    act(() => {
+      fireEvent.change(getByLabelText('attach'), {
+        target: { files: [file] },
+      });
+
+      fireEvent.submit(getByTestId('form'));
+    });
+
+    await wait(() => {
+      expect((getByLabelText('attach') as HTMLInputElement).value).toBe('');
+    });
+  });
+});

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,7 +3,7 @@ import { hot } from 'react-hot-loader/root';
 import * as Yup from 'yup';
 
 import {
- Form, Input, Select, Scope, SubmitHandler,
+  Form, Input, Select, Scope, SubmitHandler, FileInput,
 } from '../../lib';
 import DatePicker from './components/DatePicker';
 import ReactSelect from './components/ReactSelect';
@@ -28,6 +28,7 @@ const schema = Yup.object().shape({
     }),
     otherwise: Yup.object().strip(true),
   }),
+  attach: Yup.string(),
 });
 
 interface Data {
@@ -39,6 +40,7 @@ interface Data {
   billingAddress: {
     number: number;
   };
+  attach: string;
 }
 
 function App() {
@@ -55,6 +57,7 @@ function App() {
     billingAddress: {
       number: 833,
     },
+    attach: '',
   });
 
   const handleSubmit: SubmitHandler<Data> = (data, { resetForm }) => {
@@ -112,6 +115,8 @@ function App() {
         <Input name="street" />
         <Input name="number" />
       </Scope>
+
+      <FileInput name="attach" label="Attachment" />
 
       <button type="submit">Enviar</button>
     </Form>

--- a/lib/components/FileInput.tsx
+++ b/lib/components/FileInput.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef, useState, ChangeEvent } from "react";
+import React, { useEffect, useRef, useState, ChangeEvent } from 'react';
 
-import useField from "../useField";
+import useField from '../useField';
 
 interface Props {
   name: string;
@@ -8,7 +8,7 @@ interface Props {
   onStartProgress?: (progress: number, event: ProgressEvent) => void;
 }
 
-type InputProps = JSX.IntrinsicElements["input"] & Props;
+type InputProps = JSX.IntrinsicElements['input'] & Props;
 
 export default function Input({
   name,
@@ -25,11 +25,11 @@ export default function Input({
       registerField({
         name: fieldName,
         ref: ref.current,
-        path: "dataset.file",
+        path: 'dataset.file',
         clearValue: (fileRef: HTMLInputElement) => {
-          fileRef.value = "";
-          setFile("");
-        }
+          fileRef.value = '';
+          setFile('');
+        },
       });
     }
   }, [ref.current, fieldName]);
@@ -39,7 +39,7 @@ export default function Input({
     ref,
     id: fieldName,
     name: fieldName,
-    "aria-label": fieldName
+    'aria-label': fieldName,
   };
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {

--- a/lib/components/FileInput.tsx
+++ b/lib/components/FileInput.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useRef, useState, ChangeEvent } from "react";
+
+import useField from "../useField";
+
+interface Props {
+  name: string;
+  label?: string;
+  onStartProgress?: (progress: number, event: ProgressEvent) => void;
+}
+
+type InputProps = JSX.IntrinsicElements["input"] & Props;
+
+export default function Input({
+  name,
+  label,
+  onStartProgress,
+  ...rest
+}: InputProps) {
+  const ref = useRef<HTMLInputElement>(null);
+  const { fieldName, registerField, defaultValue, error } = useField(name);
+  const [file, setFile] = useState(defaultValue);
+
+  useEffect(() => {
+    if (ref.current) {
+      registerField({
+        name: fieldName,
+        ref: ref.current,
+        path: "dataset.file",
+        clearValue: (fileRef: HTMLInputElement) => {
+          fileRef.value = "";
+          setFile("");
+        }
+      });
+    }
+  }, [ref.current, fieldName]);
+
+  const props = {
+    ...rest,
+    ref,
+    id: fieldName,
+    name: fieldName,
+    "aria-label": fieldName
+  };
+
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    const fileReader = new FileReader();
+
+    fileReader.onload = (evt: ProgressEvent) => {
+      const { result } = evt.target as any;
+      setFile(result);
+    };
+
+    fileReader.onprogress = (evt: ProgressEvent) => {
+      /* istanbul ignore next  */
+      const { loaded = 0, total = 0 } = evt;
+      const progress = (loaded / total) * 100;
+
+      if (onStartProgress) {
+        onStartProgress(progress, evt);
+      }
+    };
+
+    const { files } = event.target;
+    if (files) {
+      fileReader.readAsDataURL(files[0]);
+    }
+  }
+
+  return (
+    <>
+      {label && <label htmlFor={fieldName}>{label}</label>}
+
+      <input {...props} type="file" onChange={handleChange} data-file={file} />
+
+      {error && <span>{error}</span>}
+    </>
+  );
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,22 +1,23 @@
 /**
  * Hooks
  */
-export { default as useField } from './useField';
+export { default as useField } from "./useField";
 
 /**
  * Main components
  */
-export { default as Form } from './Form';
-export { default as Scope } from './Scope';
+export { default as Form } from "./Form";
+export { default as Scope } from "./Scope";
 
 /**
  * Form components
  */
-export { default as Input } from './components/Input';
-export { default as Textarea } from './components/Textarea';
-export { default as Select } from './components/Select';
+export { default as Input } from "./components/Input";
+export { default as Textarea } from "./components/Textarea";
+export { default as Select } from "./components/Select";
+export { default as FileInput } from "./components/FileInput";
 
 /**
  * Types
  */
-export { SubmitHandler } from './Form';
+export { SubmitHandler } from "./Form";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,23 +1,23 @@
 /**
  * Hooks
  */
-export { default as useField } from "./useField";
+export { default as useField } from './useField';
 
 /**
  * Main components
  */
-export { default as Form } from "./Form";
-export { default as Scope } from "./Scope";
+export { default as Form } from './Form';
+export { default as Scope } from './Scope';
 
 /**
  * Form components
  */
-export { default as Input } from "./components/Input";
-export { default as Textarea } from "./components/Textarea";
-export { default as Select } from "./components/Select";
-export { default as FileInput } from "./components/FileInput";
+export { default as Input } from './components/Input';
+export { default as Textarea } from './components/Textarea';
+export { default as Select } from './components/Select';
+export { default as FileInput } from './components/FileInput';
 
 /**
  * Types
  */
-export { SubmitHandler } from "./Form";
+export { SubmitHandler } from './Form';


### PR DESCRIPTION
<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/unform/blob/master/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- Ensure you have added or ran the appropriate tests for your PR -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**

Send files easily by adding new fields of type `FileInput`.
<!--- Describe the change below, including rationale and design decisions -->

<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->

**Additional context**

With the `FileInput` component you can also retrieve the progress of the upload when it is loaded into memory. This can be useful for blocking some buttons while the process is not complete preventing incomplete file data from being sent.

Example:

```jsx
<FileInput name="attach" onStartProgress={(progress) => console.log(progress)} />
```
<!-- Add any other context or screenshots about the feature request here. -->
