### PR TITLE
chore: Run lint-staged on tests and example

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}
+

--- a/lib/Form.tsx
+++ b/lib/Form.tsx
@@ -47,8 +47,8 @@ export default function Form({
     const data = {};
 
     fields.forEach(({
- name, ref, path, parseValue,
-}) => {
+      name, ref, path, parseValue,
+    }) => {
       const value = dot.pick(path, ref);
 
       data[name] = parseValue ? parseValue(value) : value;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,14 @@
       "eslint --fix",
       "prettier --write",
       "jest --bail --findRelatedTests"
+    ],
+    "__tests__/**/*.{ts,tsx}" : [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "example/**/*.{ts,tsx}" : [
+      "eslint --fix",
+      "prettier --write"
     ]
   },
   "scripts": {


### PR DESCRIPTION
**Changes proposed**
Tests and example files were not being linted by lint-staged.

Now lint-staged run over tests and example folders.

Fix prettier integration issues where in some cases trailing comma and single quotes were not being used.

Closes #78.

**Additional context**

