### PR TITLE
fix: Consider context inside unregisterField

### DIFF
--- a/lib/Form.tsx
+++ b/lib/Form.tsx
@@ -116,7 +116,7 @@ export default function Form({
   }
 
   function unregisterField(name: string) {
-    setFields(fields.filter(field => field.name !== name));
+    setFields(state => state.filter(field => field.name !== name));
   }
 
   return (


### PR DESCRIPTION
**Changes proposed**

Make `setFields` consider the state queue when running `unregisterField`

**Additional context**

Without this fix, when you would cause a field to be unmounted, the whole `fields` stack would be lost, causing Unform to lose reference to all its fields. Now, because we're actually passing an arrow function, react will run our code inside the update queue, which should resolve the issue.