### PR TITLE
feat: Add Check and Choice components

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Unform is a performance focused library that helps you creating beautiful forms 
     - [Input element](#input-element)
     - [Select element](#select-element)
     - [File Input element](#file-input-element)
+    - [Choice element](#choice-element)
+    - [Check element](#check-element)
   - [Reset Form](#reset-form)
   - [Nested fields](#nested-fields)
   - [Initial data](#initial-data)
@@ -194,6 +196,91 @@ function App() {
   );
 }
 ```
+
+**↑ back to:** [Table of contents](#table-of-contents) · [Guides](#guides)
+
+<hr>
+
+#### Choice element
+
+Choice element represents multiple options elements.
+The `options` property is the options list, and is necessary.
+
+It will display checkboxes or radio buttons based on `multiple` property.
+
+To display multiple checkboxes:
+```js
+import React from 'react';
+import { Form, FileInput } from '@rocketseat/unform';
+
+function App() {
+  function handleSubmit(data) {}
+
+  function handleProgress(progress, event) {}
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Choice name="fieldName" options={[
+        { value: '1', label: 'One' },
+        { value: '2', label: 'Two' }
+      ]} multiple />
+
+      <button type="submit">Send</button>
+    </Form>
+  );
+}
+```
+When the value is returned, the format is an array of selected values (*..., fieldName: ['1', '2', ...], ...*).
+
+
+To display multiple radio buttons:
+```js
+import React from 'react';
+import { Form, Choice } from '@rocketseat/unform';
+
+function App() {
+  function handleSubmit(data) {}
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Choice name="fieldName" options={[
+        { value: '1', label: 'One' },
+        { value: '2', label: 'Two' }
+      ]} />
+
+      <button type="submit">Send</button>
+    </Form>
+  );
+}
+```
+When the value is returned in this case, the format will be the value selected (*..., fieldName: '1', ...*).
+
+
+**↑ back to:** [Table of contents](#table-of-contents) · [Guides](#guides)
+
+<hr>
+
+#### Check element
+
+This component display only one option in form of a single checkbox.
+
+```js
+import React from 'react';
+import { Form, Check } from '@rocketseat/unform';
+
+function App() {
+  function handleSubmit(data) {}
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Check name="fieldName" label="Test Field" />
+
+      <button type="submit">Send</button>
+    </Form>
+  );
+}
+```
+The value of this element will be true if checked or false otherwise (*..., fieldName: true, ...*).
 
 **↑ back to:** [Table of contents](#table-of-contents) · [Guides](#guides)
 

--- a/__tests__/components/Check.spec.tsx
+++ b/__tests__/components/Check.spec.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import 'react-testing-library/cleanup-after-each';
+import 'jest-dom/extend-expect';
+import { render, fireEvent, wait } from 'react-testing-library';
+import * as Yup from 'yup';
+
+import { Form, Check } from '../../lib';
+
+describe('Form', () => {
+  it('should display label', () => {
+    const { getByText } = render(
+      <Form onSubmit={jest.fn()}>
+        <Check name="check" label="Check" />
+      </Form>
+    );
+
+    expect(!!getByText('Check')).toBe(true);
+  });
+
+  it('should display error', async () => {
+    const schema = Yup.object().shape({
+      check: Yup.boolean().oneOf([true], 'Check is required'),
+    });
+
+    const { getByText, getByTestId } = render(
+      <Form schema={schema} onSubmit={jest.fn()}>
+        <Check name="check" label="Check" />
+      </Form>
+    );
+
+    fireEvent.submit(getByTestId('form'));
+    await wait(() => expect(!!getByText('Check is required')).toBe(true));
+  });
+
+  it('should return true if default value is true', () => {
+    const submitMock = jest.fn();
+
+    const { getByTestId } = render(
+      <Form onSubmit={submitMock} initialData={{ check: true }}>
+        <Check name="check" label="Check" />
+      </Form>
+    );
+
+    fireEvent.submit(getByTestId('form'));
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        check: true,
+      },
+      {
+        resetForm: expect.any(Function),
+      }
+    );
+  });
+
+  it('should return true if selected', () => {
+    const submitMock = jest.fn();
+
+    const { getByTestId, getByLabelText } = render(
+      <Form onSubmit={submitMock}>
+        <Check name="check" label="Check" />
+      </Form>
+    );
+
+    fireEvent.click(getByLabelText('Check'));
+    fireEvent.submit(getByTestId('form'));
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        check: true,
+      },
+      {
+        resetForm: expect.any(Function),
+      }
+    );
+  });
+
+  it('should return false unless selected', () => {
+    const submitMock = jest.fn();
+
+    const { getByTestId } = render(
+      <Form onSubmit={submitMock}>
+        <Check name="check" label="Check" />
+      </Form>
+    );
+
+    fireEvent.submit(getByTestId('form'));
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        check: false,
+      },
+      {
+        resetForm: expect.any(Function),
+      }
+    );
+  });
+});

--- a/__tests__/components/Check.spec.tsx
+++ b/__tests__/components/Check.spec.tsx
@@ -92,4 +92,16 @@ describe('Form', () => {
       }
     );
   });
+
+  it('should reset state after submit', () => {
+    const { getByTestId, getByLabelText } = render(
+      <Form onSubmit={(_, { resetForm }) => resetForm()}>
+        <Check name="check" label="Check" />
+      </Form>
+    );
+
+    fireEvent.submit(getByTestId('form'));
+
+    expect((getByLabelText('check') as HTMLInputElement).checked).toBe(false);
+  });
 });

--- a/__tests__/components/Choice.spec.tsx
+++ b/__tests__/components/Choice.spec.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import 'react-testing-library/cleanup-after-each';
+import 'jest-dom/extend-expect';
+import { render, fireEvent, wait, act } from 'react-testing-library';
+import * as Yup from 'yup';
+
+import { Form, Choice } from '../../lib';
+
+const expectCheckbox = (field: HTMLElement, checked: boolean) => {
+  expect((field as HTMLInputElement).checked).toBe(checked);
+};
+
+describe('Form', () => {
+  it('should display labels if specified', () => {
+    const { getByText } = render(
+      <Form onSubmit={jest.fn()}>
+        <Choice name="choice" options={[{ value: '1', label: 'choice_1' }]} />
+      </Form>
+    );
+
+    expect(getByText('choice_1')).toBeDefined();
+  });
+
+  it('should not display labels unless specified', () => {
+    const { getByText } = render(
+      <Form onSubmit={jest.fn()}>
+        <Choice name="choice" options={[{ value: '1' }]} />
+      </Form>
+    );
+
+    expect(() => getByText('choice_1')).toThrow(/^Unable to find an element.*/);
+  });
+
+  it('should display errors', async () => {
+    const schema = Yup.object().shape({
+      choice: Yup.array(Yup.string())
+        .min(1)
+        .required('Choice is required'),
+    });
+
+    const { getByText, getByTestId } = render(
+      <Form schema={schema} onSubmit={jest.fn()}>
+        <Choice name="choice" options={[{ value: '1', label: 'choice_1' }]} />
+      </Form>
+    );
+
+    act(() => {
+      fireEvent.submit(getByTestId('form'));
+    });
+    await wait(() => expect(!!getByText('Choice is required')).toBe(true));
+  });
+
+  it('should return array of values if multiple', () => {
+    const submitMock = jest.fn();
+
+    const { getByTestId, getByLabelText } = render(
+      <Form onSubmit={submitMock}>
+        <Choice
+          name="choice"
+          options={[
+            { value: '1', label: 'choice_1' },
+            { value: '2', label: 'choice_2' },
+            { value: '3', label: 'choice_3' },
+            { value: '4', label: 'choice_4' },
+          ]}
+          multiple
+        />
+      </Form>
+    );
+
+    fireEvent.click(getByLabelText('choice_1'));
+    fireEvent.click(getByLabelText('choice_3'));
+    fireEvent.submit(getByTestId('form'));
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        choice: ['1', '3'],
+      },
+      {
+        resetForm: expect.any(Function),
+      }
+    );
+  });
+
+  it('should return single value unless multiple', () => {
+    const submitMock = jest.fn();
+
+    const { getByTestId, getByLabelText } = render(
+      <Form onSubmit={submitMock}>
+        <Choice
+          name="choice"
+          options={[
+            { value: '1', label: 'choice_1' },
+            { value: '2', label: 'choice_2' },
+            { value: '3', label: 'choice_3' },
+            { value: '4', label: 'choice_4' },
+          ]}
+        />
+      </Form>
+    );
+
+    fireEvent.click(getByLabelText('choice_1'));
+    fireEvent.click(getByLabelText('choice_3'));
+    fireEvent.submit(getByTestId('form'));
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        choice: '3',
+      },
+      {
+        resetForm: expect.any(Function),
+      }
+    );
+  });
+
+  it('should default check field if initialData supplied as array', async () => {
+    const { getByLabelText } = render(
+      <Form onSubmit={() => {}} initialData={{ tech: ['node', 'react'] }}>
+        <Choice
+          name="tech"
+          multiple
+          options={[
+            { value: 'node', label: 'NodeJS' },
+            { value: 'react', label: 'ReactJS' },
+            { value: 'rn', label: 'React Native' },
+          ]}
+        />
+      </Form>
+    );
+    expectCheckbox(getByLabelText('NodeJS'), true);
+    expectCheckbox(getByLabelText('ReactJS'), true);
+    expectCheckbox(getByLabelText('React Native'), false);
+  });
+
+  it('should default check field if initialData supplied as string', async () => {
+    const { getByLabelText } = render(
+      <Form onSubmit={() => {}} initialData={{ tech: 'react' }}>
+        <Choice
+          name="tech"
+          multiple
+          options={[
+            { value: 'node', label: 'NodeJS' },
+            { value: 'react', label: 'ReactJS' },
+            { value: 'rn', label: 'React Native' },
+          ]}
+        />
+      </Form>
+    );
+    expectCheckbox(getByLabelText('NodeJS'), false);
+    expectCheckbox(getByLabelText('ReactJS'), true);
+    expectCheckbox(getByLabelText('React Native'), false);
+  });
+
+  it('should not default check field unless initialData supplied', async () => {
+    const { getByLabelText } = render(
+      <Form onSubmit={() => {}}>
+        <Choice
+          name="tech"
+          multiple
+          options={[
+            { value: 'node', label: 'NodeJS' },
+            { value: 'react', label: 'ReactJS' },
+            { value: 'rn', label: 'React Native' },
+          ]}
+        />
+      </Form>
+    );
+    expectCheckbox(getByLabelText('NodeJS'), false);
+    expectCheckbox(getByLabelText('ReactJS'), false);
+    expectCheckbox(getByLabelText('React Native'), false);
+  });
+});

--- a/__tests__/components/Choice.spec.tsx
+++ b/__tests__/components/Choice.spec.tsx
@@ -167,4 +167,28 @@ describe('Form', () => {
     expectCheckbox(getByLabelText('ReactJS'), false);
     expectCheckbox(getByLabelText('React Native'), false);
   });
+
+  it('should reset state after submit', () => {
+    const { getByTestId, getByLabelText } = render(
+      <Form
+        onSubmit={(_, { resetForm }) => resetForm()}
+        initialData={{ tech: ['node', 'react'] }}
+      >
+        <Choice
+          name="tech"
+          multiple
+          options={[
+            { value: 'node', label: 'NodeJS' },
+            { value: 'react', label: 'ReactJS' },
+            { value: 'rn', label: 'React Native' },
+          ]}
+        />
+      </Form>
+    );
+
+    fireEvent.submit(getByTestId('form'));
+    expectCheckbox(getByLabelText('NodeJS'), false);
+    expectCheckbox(getByLabelText('ReactJS'), false);
+    expectCheckbox(getByLabelText('React Native'), false);
+  });
 });

--- a/__tests__/utils/CustomInputParse.tsx
+++ b/__tests__/utils/CustomInputParse.tsx
@@ -9,17 +9,16 @@ interface Props extends InputHTMLAttributes<HTMLInputElement> {
 
 export default function Input({ name, label, ...rest }: Props) {
   const ref = useRef<HTMLInputElement>(null);
-  const {
- fieldName, registerField, defaultValue, error,
-} = useField(name);
+  const { fieldName, registerField, defaultValue, error } = useField(name);
 
   useEffect(() => {
     if (ref.current) {
       registerField({
         name: fieldName,
         ref: ref.current,
-        path: 'value',
-        parseValue: (value: string) => value.concat('-test'),
+        path: '',
+        parseValue: (currentRef: HTMLInputElement) =>
+          currentRef.value.concat('-test'),
       });
     }
   }, [ref.current, fieldName]);

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,7 +3,13 @@ import { hot } from 'react-hot-loader/root';
 import * as Yup from 'yup';
 
 import {
-  Form, Input, Select, Scope, SubmitHandler, FileInput,
+  Form,
+  Input,
+  Select,
+  Scope,
+  SubmitHandler,
+  FileInput,
+  Check,
 } from '../../lib';
 import DatePicker from './components/DatePicker';
 import ReactSelect from './components/ReactSelect';
@@ -30,6 +36,8 @@ const schema = Yup.object().shape({
     otherwise: Yup.object().strip(true),
   }),
   attach: Yup.string(),
+  termo1: Yup.boolean(),
+  termo2: Yup.boolean().oneOf([true], 'Termo 2 é obrigatório'),
 });
 
 interface Data {
@@ -43,24 +51,28 @@ interface Data {
     number: number;
   };
   attach: string;
+  termo1: boolean;
+  termo2: boolean;
 }
 
 function App() {
   const [useShippingAsBilling, setUseShippingAsBilling] = useState<boolean>(
-    true,
+    true
   );
 
   const [formData] = useState<Data>({
-    name: "Diego",
-    profile: "CTO na Rocketseat",
-    theme: "dracula",
-    tech: "node",
-    people: ["1", "3"],
+    name: 'Diego',
+    profile: 'CTO na Rocketseat',
+    theme: 'dracula',
+    tech: 'node',
+    people: ['1', '3'],
     date: new Date(),
     billingAddress: {
       number: 833,
     },
     attach: '',
+    termo1: true,
+    termo2: false,
   });
 
   const handleSubmit: SubmitHandler<Data> = (data, { resetForm }) => {
@@ -83,9 +95,9 @@ function App() {
         name="theme"
         placeholder="Selecione..."
         options={[
-          { id: "dracula", title: "Dracula" },
-          { id: "material", title: "Material" },
-          { id: "shades-of-purple", title: "Shades of Purple" }
+          { id: 'dracula', title: 'Dracula' },
+          { id: 'material', title: 'Material' },
+          { id: 'shades-of-purple', title: 'Shades of Purple' },
         ]}
       />
 
@@ -131,6 +143,12 @@ function App() {
 
       <FileInput name="attach" label="Attachment" />
 
+      <br />
+      <Check name="termo1" label="Aceita o Termo 1?" />
+      <br />
+      <Check name="termo2" label="Aceita o Termo 2 (obrigatório)?" />
+
+      <br />
       <button type="submit">Enviar</button>
     </Form>
   );

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -10,6 +10,7 @@ import {
   SubmitHandler,
   FileInput,
   Check,
+  Choice,
 } from '../../lib';
 import DatePicker from './components/DatePicker';
 import ReactSelect from './components/ReactSelect';
@@ -38,6 +39,10 @@ const schema = Yup.object().shape({
   attach: Yup.string(),
   termo1: Yup.boolean(),
   termo2: Yup.boolean().oneOf([true], 'Termo 2 é obrigatório'),
+  choice1: Yup.array(Yup.string())
+    .min(1)
+    .required(),
+  choice2: Yup.string().required(),
 });
 
 interface Data {
@@ -53,6 +58,8 @@ interface Data {
   attach: string;
   termo1: boolean;
   termo2: boolean;
+  choice1: string[];
+  choice2: string;
 }
 
 function App() {
@@ -73,6 +80,8 @@ function App() {
     attach: '',
     termo1: true,
     termo2: false,
+    choice1: ['2', '3'],
+    choice2: '',
   });
 
   const handleSubmit: SubmitHandler<Data> = (data, { resetForm }) => {
@@ -147,6 +156,30 @@ function App() {
       <Check name="termo1" label="Aceita o Termo 1?" />
       <br />
       <Check name="termo2" label="Aceita o Termo 2 (obrigatório)?" />
+      <br />
+
+      <Choice
+        name="choice1"
+        options={[
+          { value: '1', label: 'Um' },
+          { value: '2', label: 'Dois' },
+          { value: '3', label: 'Três' },
+          { value: '4', label: 'Quatro' },
+        ]}
+        multiple
+      />
+      <br />
+
+      <Choice
+        name="choice2"
+        options={[
+          { value: '1', label: 'Um' },
+          { value: '2', label: 'Dois' },
+          { value: '3', label: 'Três' },
+          { value: '4', label: 'Quatro' },
+        ]}
+      />
+      <br />
 
       <br />
       <button type="submit">Enviar</button>

--- a/example/src/components/ReactSelect.tsx
+++ b/example/src/components/ReactSelect.tsx
@@ -23,11 +23,10 @@ export default function ReactSelect({
   ...rest
 }: Props) {
   const ref = useRef(null);
-  const {
- fieldName, registerField, defaultValue, error,
-} = useField(name);
+  const { fieldName, registerField, defaultValue, error } = useField(name);
 
-  function parseSelectValue(selectValue) {
+  function parseSelectValue(selectRef) {
+    const selectValue = selectRef.state.value;
     if (!multiple) {
       return selectValue ? selectValue.id : '';
     }
@@ -41,7 +40,7 @@ export default function ReactSelect({
       ref: ref.current,
       path: 'state.value',
       parseValue: parseSelectValue,
-      clearValue: (selectRef) => {
+      clearValue: selectRef => {
         selectRef.select.clearValue();
       },
     });

--- a/lib/Form.tsx
+++ b/lib/Form.tsx
@@ -56,7 +56,7 @@ export default function Form({
     fields.forEach(({ name, ref, path, parseValue }) => {
       const value = dot.pick(path, ref);
 
-      data[name] = parseValue ? parseValue(value) : value;
+      data[name] = parseValue ? parseValue(ref) : value;
     });
 
     dot.object(data);

--- a/lib/components/Check.tsx
+++ b/lib/components/Check.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef } from 'react';
+
+import useField from '../useField';
+
+interface Props {
+  name: string;
+  label?: string;
+}
+
+type InputProps = JSX.IntrinsicElements['input'] & Props;
+
+export default function Input({ name, label, ...rest }: InputProps) {
+  const ref = useRef<HTMLInputElement>(null);
+  const { fieldName, registerField, defaultValue, error } = useField(name);
+
+  const parseValue = (inputRef: HTMLInputElement) => inputRef.checked;
+
+  useEffect(() => {
+    if (ref.current) {
+      registerField({
+        name: fieldName,
+        ref: ref.current,
+        path: '',
+        parseValue,
+        clearValue: (inputRef: HTMLInputElement) => {
+          inputRef.checked = false;
+        },
+      });
+    }
+  }, [ref.current, fieldName]);
+
+  const props = {
+    ...rest,
+    ref,
+    id: fieldName,
+    name: fieldName,
+    type: 'checkbox',
+    'aria-label': fieldName,
+    defaultChecked: defaultValue,
+  };
+
+  return (
+    <>
+      <input {...props as InputProps} />
+
+      {label && <label htmlFor={fieldName}>{label}</label>}
+
+      {error && <span>{error}</span>}
+    </>
+  );
+}

--- a/lib/components/Choice.tsx
+++ b/lib/components/Choice.tsx
@@ -1,0 +1,80 @@
+import React, { Fragment, useEffect, useRef } from 'react';
+
+import useField from '../useField';
+
+interface OptionProps {
+  value: string;
+  label?: string;
+}
+
+interface Props {
+  name: string;
+  options: OptionProps[];
+  multiple?: boolean;
+}
+
+type ChoiceProps = JSX.IntrinsicElements['input'] & Props;
+
+export default function Choice({
+  name,
+  options,
+  multiple,
+  ...rest
+}: ChoiceProps) {
+  const { fieldName, registerField, defaultValue, error } = useField(name);
+  const ref = useRef<HTMLInputElement[] | null[]>([]);
+
+  const nativeField = multiple ? 'checkbox' : 'radio';
+
+  const checked = (value: string): boolean => {
+    if (!defaultValue) return false;
+    if (typeof defaultValue === 'string') return [defaultValue].includes(value);
+    return Array.from(defaultValue).includes(value);
+  };
+
+  const parseValue = (choiceRef: HTMLInputElement[]) => {
+    const values = choiceRef.filter(i => i.checked).map(i => i.value);
+    return multiple ? values : values[0];
+  };
+
+  useEffect(() => {
+    ref.current = ref.current.slice(0, options.length);
+    registerField({
+      name: fieldName,
+      path: '',
+      ref: ref.current,
+      parseValue,
+      clearValue: (choiceRef: HTMLInputElement[]) => {
+        choiceRef.forEach(i => {
+          i.checked = false;
+        });
+      },
+    });
+  }, [fieldName]);
+
+  return (
+    <Fragment>
+      {options.map(({ value, label }, idx) => {
+        const checkboxId = `${fieldName}-${value}`;
+        return (
+          <Fragment key={checkboxId}>
+            <input
+              {...rest}
+              ref={el => {
+                ref.current[idx] = el;
+              }}
+              type={nativeField}
+              id={checkboxId}
+              name={fieldName}
+              aria-label={checkboxId}
+              value={value}
+              defaultChecked={checked(value)}
+            />
+            {label && <label htmlFor={checkboxId}>{label}</label>}
+          </Fragment>
+        );
+      })}
+      {error && <span>{error}</span>}
+    </Fragment>
+  );
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -16,6 +16,7 @@ export { default as Input } from './components/Input';
 export { default as Textarea } from './components/Textarea';
 export { default as Select } from './components/Select';
 export { default as FileInput } from './components/FileInput';
+export { default as Check } from './components/Check';
 
 /**
  * Types

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -17,6 +17,7 @@ export { default as Textarea } from './components/Textarea';
 export { default as Select } from './components/Select';
 export { default as FileInput } from './components/FileInput';
 export { default as Check } from './components/Check';
+export { default as Choice } from './components/Choice';
 
 /**
  * Types

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,11 @@
 export interface UnformField {
   name: string;
-  ref?: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
+  ref?:
+    | HTMLInputElement
+    | HTMLTextAreaElement
+    | HTMLSelectElement
+    | HTMLInputElement[]
+    | null[];
   path: string;
   parseValue?: Function;
   clearValue?: Function;


### PR DESCRIPTION
<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/unform/blob/master/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- Ensure you have added or ran the appropriate tests for your PR -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
This resolves some aspects discussed in #20 and #66

This PR provides two new components:
* Check - for single options rendered as a single checkbox 
* Choice - for multiple options rendered as checkboxes or radio buttons

For Check component, the value returned will be _true_ or _false_.
For Choice component, if checkboxes (_multiple_ property) array of values will be returned, if radio buttons, only one string will be returned.

To made this possible, parseValue method was changed to receive the component ref instead of value.
<!--- Describe the change below, including rationale and design decisions -->

<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->

**Additional context**
```html
<Check name="fieldName" label="Test Field" />
```
will render
```html
<input type="checkbox" id="fieldName" name="fieldName" />
<label for="fieldName">TestField</label>
```
and when form is submitted, you will receive `{ ..., fieldName: true | false, ... }`

```html
<Choice name="fieldName" options={[
  { value: '1', label: 'One' }, { value: '2', label: 'Two' }
]} multiple />
```
will render
```html
<input type="checkbox" id="fieldName-1" name="fieldName" value="1">
<label for="fieldName-1">One</label>
<input type="checkbox" id="fieldName-2" name="fieldName" value="2">
<label for="fieldName-2">Two</label>
```
and when form is submitted, you will receive `{ ..., fieldName: ['1', '2'], ...}` (if selected)


```html
<Choice name="fieldName" options={[
  { value: '1', label: 'One' }, { value: '2', label: 'Two' }
]} />
```
will render
```html
<input type="radio" id="fieldName-1" name="fieldName" value="1">
<label for="fieldName-1">One</label>
<input type="radio" id="fieldName-2" name="fieldName" value="2">
<label for="fieldName-2">Two</label>
```
and when form is submitted, you will receive `{ ..., fieldName: '1' | '2', ...}` (if selected)
<!-- Add any other context or screenshots about the feature request here. -->
