### PR TITLE
feat: Allow setting data on resetForm

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,34 @@ function App() {
 }
 ```
 
+_Optional:_ `resetForm` may receive an object that will be applied when the form is reset.
+
+```js
+import React from 'react';
+import { Form, Input } from '@rocketseat/unform';
+
+const options = [
+  { id: 'react', title: 'ReactJS' },
+  { id: 'node', title: 'NodeJS' },
+  { id: 'rn', title: 'React Native' },
+];
+
+function App() {
+  function handleSubmit(data, { resetForm }) {
+    resetForm({ tech: 'react' });
+  }
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Select name="tech" options={options} />
+
+      <button type="submit">Send</button>
+    </Form>
+  );
+}
+```
+
+
 ### Nested fields
 
 ```js

--- a/__tests__/Form.spec.tsx
+++ b/__tests__/Form.spec.tsx
@@ -161,6 +161,36 @@ describe('Form', () => {
     expect((getByLabelText('tech') as HTMLSelectElement).value).toBe('');
   });
 
+  it('should apply data when resetForm is dispatched with new values', () => {
+    const newData = {
+      name: 'John Doe',
+      tech: 'react'
+    };
+
+    const { getByTestId, getByLabelText } = render(
+      <Form onSubmit={(_, { resetForm }) => resetForm(newData)}>
+        <Input name="name" />
+        <Select
+          name="tech"
+          placeholder="Select..."
+          options={[
+            { id: "node", title: "NodeJS" },
+            { id: "react", title: "ReactJS" },
+          ]}
+        />
+      </Form>
+    );
+
+    getByLabelText('name').setAttribute('value', 'Diego');
+
+    fireEvent.change(getByLabelText('tech'), { target: { value: 'node' } });
+
+    fireEvent.submit(getByTestId('form'));
+
+    expect((getByLabelText('name') as HTMLInputElement).value).toBe('John Doe');
+    expect((getByLabelText('tech') as HTMLSelectElement).value).toBe('react');
+  });
+
   it('should be able to have custom value parser', () => {
     const submitMock = jest.fn();
 

--- a/lib/Form.tsx
+++ b/lib/Form.tsx
@@ -20,7 +20,7 @@ interface Context {
 }
 
 interface Helpers {
-  resetForm: () => void;
+  resetForm: (data?: object) => void;
 }
 
 interface FormContent {
@@ -64,13 +64,13 @@ export default function Form({
     return data;
   }
 
-  function resetForm() {
-    fields.forEach(({ ref, path, clearValue }) => {
+  function resetForm(data = {}) {
+    fields.forEach(({ name, ref, path, clearValue }) => {
       if (clearValue) {
-        return clearValue(ref);
+        return clearValue(ref, data[name]);
       }
 
-      return dot.set(path, '', ref as object);
+      return dot.set(path, data[name] ? data[name] : '', ref as object);
     });
   }
 


### PR DESCRIPTION
**Changes proposed**

The resetForm helper function can now receive an optional object that updates the form data, if no value is provided the fields are cleared by default.

Close #67.