### PR TITLE
docs: Fix import in Choice element

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ It will display checkboxes or radio buttons based on `multiple` property.
 To display multiple checkboxes:
 ```js
 import React from 'react';
-import { Form, FileInput } from '@rocketseat/unform';
+import { Form, Choice } from '@rocketseat/unform';
 
 function App() {
   function handleSubmit(data) {}


### PR DESCRIPTION
Line 214 shows an example of using the Choice element, but imported FileInput instead of Choice.
Change FileInput to Choice in Choice element.
