### PR TITLE
fix(unform): Fix reset form function in form

### DIFF
--- a/lib/Form.tsx
+++ b/lib/Form.tsx
@@ -64,12 +64,15 @@ export default function Form({
     return data;
   }
 
-  function resetForm(data = {}) {
+  function resetForm(data = {}, focusedElement = '') {
     fields.forEach(({ name, ref, path, clearValue }) => {
       if (clearValue) {
         return clearValue(ref, data[name]);
       }
-
+      if (focusedElement && name === focusedElement) {
+        const newRef = ref as HTMLElement;
+        newRef.focus();
+      }
       return dot.set(path, data[name] ? data[name] : '', ref as object);
     });
   }

--- a/lib/Form.tsx
+++ b/lib/Form.tsx
@@ -70,8 +70,7 @@ export default function Form({
         return clearValue(ref, data[name]);
       }
       if (focusedElement && name === focusedElement) {
-        const newRef = ref as HTMLElement;
-        newRef.focus();
+        (ref as HTMLElement).focus();
       }
       return dot.set(path, data[name] ? data[name] : '', ref as object);
     });


### PR DESCRIPTION
<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/unform/blob/master/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- Ensure you have added or ran the appropriate tests for your PR -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**

i modified the resetForm function in Form.tsx to accept a second param called focusedElement, so you can pass the element that need to be focused after the reset statement.
<!--- Describe the change below, including rationale and design decisions -->

<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->
Fixes #168 
**Additional context**
<!-- Add any other context or screenshots about the feature request here. -->

![image](https://user-images.githubusercontent.com/4451937/73283792-64e6b400-41d2-11ea-9780-5a69f231b7cc.png)

the second param in resetForm is an element to be focused. 
the result is:
![deepin-screen-recorder_Select area_20200127144909](https://user-images.githubusercontent.com/4451937/73199850-62be2000-4114-11ea-8952-641f8d69ca10.gif)


