### PR TITLE
docs: Fix Input Mask Example

### DIFF
--- a/docs/src/docs/examples/react-input-mask.mdx
+++ b/docs/src/docs/examples/react-input-mask.mdx
@@ -28,7 +28,7 @@ const InputMask: React.FC<Props> = ({ name, ...rest }) => {
       ref: inputRef.current,
       path: 'value',
       setValue(ref: any, value: string) {
-        ref.setInputValue('');
+        ref.setInputValue(value);
       },
       clearValue(ref: any) {
         ref.setInputValue('');


### PR DESCRIPTION
**Changes proposed**

On setValue method ref.setInputValue was setting always an empty string causing problems when we set a default value.