### PR TITLE
docs: Replacing clearValue with clearField

### DIFF
--- a/docs/src/docs/guides/reset-form.mdx
+++ b/docs/src/docs/guides/reset-form.mdx
@@ -32,7 +32,7 @@ export default function SignIn() {
     formRef.current.reset();
 
     // You can also clear a single input value
-    formRef.current.clearValue('email');
+    formRef.current.clearField('email');
   }
 
   return (


### PR DESCRIPTION
**Changes proposed**
In the documentation, in "Reset form", you end up resetting a single input using:

`formRef.current.clearValue('email');`

However, this does not seem to work anymore, to reset a single input, you must use **clearField**, like this:

`formRef.current.clearField('email');`

I just fixed that in the documentation.

**Additional context**
These are the values that I have inside a **formRef.current**, look that there is no **clearValue**, but **clearField**.

![Screenshot from 2020-04-04 19 38 35](https://user-images.githubusercontent.com/27022914/78462790-e6affd80-76ab-11ea-9967-a15944126c4a.png)

