### PR TITLE
Fix errors and improve API

### DIFF
--- a/docs/config/sidebar.yml
+++ b/docs/config/sidebar.yml
@@ -50,6 +50,10 @@
       link: '/recipes/accessing-field-ref'
     - label: 'Styled Components'
       link: '/recipes/styled-components'
+    - label: 'Clear input error on focus'
+      link: '/recipes/clear-input-error-on-focus'
+    - label: 'Accessing form event'
+      link: '/recipes/accessing-form-event'
     - label: 'TypeScript'
       link: '/recipes/typescript'
 

--- a/docs/src/docs/guides/basic-form.mdx
+++ b/docs/src/docs/guides/basic-form.mdx
@@ -12,7 +12,7 @@ import { useField } from '@unform/core';
 
 export default function Input({ name, ...rest }) {
   const inputRef = useRef(null);
-  const { fieldName, defaultValue = '', registerField, error } = useField(name);
+  const { fieldName, defaultValue, registerField, error } = useField(name);
 
   useEffect(() => {
     registerField({

--- a/docs/src/docs/recipes/accessing-form-event.mdx
+++ b/docs/src/docs/recipes/accessing-form-event.mdx
@@ -1,0 +1,15 @@
+---
+title: Accessing form event
+---
+
+In web, you can access the form event in the 3rd parameter of the submit function.
+
+```jsx lineNumbers=true
+export default function MyForm() {
+  function handleSubmit(data, { reset }, event) {
+    console.log(event);
+  }
+
+  return <Form onSubmit={handleSubmit}>...</Form>;
+}
+```

--- a/docs/src/docs/recipes/clear-input-error-on-focus.mdx
+++ b/docs/src/docs/recipes/clear-input-error-on-focus.mdx
@@ -1,0 +1,32 @@
+---
+title: Clear input error on focus
+---
+
+Unform exposes a function called `clearError` within `useField` hook, so use it inside `onFocus` and it's done.
+
+```jsx title=components/Input.js lineNumbers=true
+import React, { useRef, useEffect } from 'react';
+import { useField } from '@unform/core';
+
+export default function Input({ name, label, ...rest }) {
+  const inputRef = useRef(null);
+
+  const { ..., clearError } = useField(name);
+
+  useEffect(() => {
+    // ... registerField
+  }, []);
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        onFocus={clearError}
+        {...rest}
+      />
+
+      {error && <span className="error">{error}</span>}
+    </>
+  );
+}
+```

--- a/packages/core/__tests__/Form.spec.tsx
+++ b/packages/core/__tests__/Form.spec.tsx
@@ -298,6 +298,24 @@ describe('Form', () => {
     expect((getByLabelText('bio') as HTMLInputElement).value).toBe('test');
   });
 
+  it('should be able to clear input error from within it', () => {
+    const formRef: RefObject<FormHandles> = { current: null };
+
+    const { getByLabelText } = render(<Input name="name" />, {
+      ref: formRef,
+    });
+
+    act(() => {
+      if (formRef.current) {
+        formRef.current.setFieldError('name', 'Name is required');
+      }
+
+      fireEvent.focus(getByLabelText('name') as HTMLInputElement);
+    });
+
+    expect(formRef.current?.getFieldError('name')).toBeUndefined();
+  });
+
   it('should be able to manually set form data', () => {
     const formRef: RefObject<FormHandles> = { current: null };
 

--- a/packages/core/__tests__/Form.spec.tsx
+++ b/packages/core/__tests__/Form.spec.tsx
@@ -67,6 +67,7 @@ describe('Form', () => {
       {
         reset: expect.any(Function),
       },
+      expect.any(Object),
     );
   });
 
@@ -93,6 +94,7 @@ describe('Form', () => {
       {
         reset: expect.any(Function),
       },
+      expect.any(Object),
     );
   });
 
@@ -152,6 +154,7 @@ describe('Form', () => {
       {
         reset: expect.any(Function),
       },
+      expect.any(Object),
     );
   });
 

--- a/packages/core/__tests__/Form.spec.tsx
+++ b/packages/core/__tests__/Form.spec.tsx
@@ -7,6 +7,7 @@ import '@testing-library/jest-dom/extend-expect.js';
 import { Form } from '../../web/lib';
 import { Scope, FormHandles } from '../lib';
 import Input from './components/Input';
+import ObjectInput from './components/ObjectInput';
 import CustomInputClear from './utils/CustomInputClear';
 import CustomInputParse from './utils/CustomInputParse';
 import render from './utils/RenderTest';
@@ -180,6 +181,7 @@ describe('Form', () => {
     const { getByLabelText } = render(
       <>
         <Input name="name" />
+        <ObjectInput name="another" />
       </>,
       {
         ref: formRef,
@@ -188,6 +190,7 @@ describe('Form', () => {
 
     if (formRef.current) {
       formRef.current.setFieldValue('name', 'John Doe');
+      formRef.current.setFieldValue('another', { id: '5', label: 'Test' });
 
       const valueNonExistent = formRef.current.setFieldValue(
         'notexists',
@@ -198,6 +201,7 @@ describe('Form', () => {
     }
 
     expect((getByLabelText('name') as HTMLInputElement).value).toBe('John Doe');
+    expect((getByLabelText('another') as HTMLInputElement).value).toBe('5');
   });
 
   it('should be able to manually get field value', () => {
@@ -301,6 +305,7 @@ describe('Form', () => {
       <>
         <Input name="name" />
         <Input name="bio" />
+        <ObjectInput name="another" />
       </>,
       {
         ref: formRef,
@@ -308,13 +313,21 @@ describe('Form', () => {
     );
 
     if (formRef.current) {
-      formRef.current.setData({ name: 'John Doe', bio: 'React developer' });
+      formRef.current.setData({
+        name: 'John Doe',
+        bio: 'React developer',
+        another: {
+          id: '5',
+          label: 'Test',
+        },
+      });
     }
 
     expect((getByLabelText('name') as HTMLInputElement).value).toBe('John Doe');
     expect((getByLabelText('bio') as HTMLInputElement).value).toBe(
       'React developer',
     );
+    expect((getByLabelText('another') as HTMLInputElement).value).toBe('5');
   });
 
   it('should be able to manually get form data', () => {

--- a/packages/core/__tests__/components/Input.tsx
+++ b/packages/core/__tests__/components/Input.tsx
@@ -18,7 +18,13 @@ function Input({
   ...rest
 }: InputProps | TextAreaProps) {
   const ref = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
-  const { fieldName, registerField, defaultValue, error } = useField(name);
+  const {
+    fieldName,
+    registerField,
+    defaultValue,
+    error,
+    clearError,
+  } = useField(name);
 
   useEffect(() => {
     if (ref.current) {
@@ -40,9 +46,9 @@ function Input({
       {label && <label htmlFor={fieldName}>{label}</label>}
 
       {multiline ? (
-        <textarea {...(props as TextAreaProps)} />
+        <textarea onFocus={clearError} {...(props as TextAreaProps)} />
       ) : (
-        <input {...(props as InputProps)} />
+        <input onFocus={clearError} {...(props as InputProps)} />
       )}
 
       {error && <span>{error}</span>}

--- a/packages/core/__tests__/components/ObjectInput.tsx
+++ b/packages/core/__tests__/components/ObjectInput.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useRef, memo } from 'react';
+
+import { useField } from '../../lib';
+
+interface InputProps {
+  name: string;
+  label?: string;
+}
+
+interface InputValue {
+  id: string;
+  label: string;
+}
+
+function Input({ name, label, ...rest }: InputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { fieldName, registerField, defaultValue, error } = useField(name);
+
+  useEffect(() => {
+    registerField<InputValue>({
+      name: fieldName,
+      ref: inputRef.current,
+      path: 'value',
+      setValue(ref: HTMLInputElement, value) {
+        ref.value = value.id;
+      },
+    });
+  }, [fieldName, registerField]);
+
+  return (
+    <>
+      {label && <label htmlFor={fieldName}>{label}</label>}
+
+      <input
+        ref={inputRef}
+        id={fieldName}
+        defaultValue={defaultValue}
+        aria-label={fieldName}
+        {...rest}
+      />
+
+      {error && <span>{error}</span>}
+    </>
+  );
+}
+
+export default memo(Input);

--- a/packages/core/__tests__/utils/CustomInputParse.tsx
+++ b/packages/core/__tests__/utils/CustomInputParse.tsx
@@ -16,7 +16,6 @@ export default function Input({ name, label, ...rest }: Props) {
       registerField({
         name: fieldName,
         ref: ref.current,
-        path: '',
         getValue: (currentRef: HTMLInputElement) =>
           currentRef.value.concat('-test'),
       });

--- a/packages/core/lib/Form.tsx
+++ b/packages/core/lib/Form.tsx
@@ -68,9 +68,13 @@ const Form: RefForwardingComponent<FormHandles, FormProps> = (
 
   const setData = useCallback(
     (data: object) => {
-      const parsedData = dot.dot(data);
+      const fieldValue = {};
 
-      Object.entries(parsedData).forEach(([fieldName, value]) => {
+      fields.current.forEach(field => {
+        fieldValue[field.name] = dot.pick(field.name, data);
+      });
+
+      Object.entries(fieldValue).forEach(([fieldName, value]) => {
         const field = getFieldByName(fieldName);
 
         if (field) {

--- a/packages/core/lib/Form.tsx
+++ b/packages/core/lib/Form.tsx
@@ -107,7 +107,7 @@ const Form: RefForwardingComponent<FormHandles, FormProps> = (
 
       const data = parseFormData();
 
-      onSubmit(data, { reset });
+      onSubmit(data, { reset }, event);
     },
     [onSubmit, parseFormData, reset],
   );

--- a/packages/core/lib/Form.tsx
+++ b/packages/core/lib/Form.tsx
@@ -130,6 +130,10 @@ const Form: RefForwardingComponent<FormHandles, FormProps> = (
     }
   }, []);
 
+  const clearFieldError = useCallback((fieldName: string) => {
+    setErrors(state => ({ ...state, [fieldName]: undefined }));
+  }, []);
+
   useImperativeHandle<{}, FormHandles>(formRef, () => ({
     getFieldValue(fieldName) {
       const field = getFieldByName(fieldName);
@@ -153,7 +157,7 @@ const Form: RefForwardingComponent<FormHandles, FormProps> = (
       return errors[fieldName];
     },
     setFieldError(fieldName, error) {
-      setErrors({ ...errors, [fieldName]: error });
+      setErrors(state => ({ ...state, [fieldName]: error }));
     },
     clearField(fieldName) {
       const field = getFieldByName(fieldName);
@@ -199,6 +203,7 @@ const Form: RefForwardingComponent<FormHandles, FormProps> = (
         scopePath: '',
         registerField,
         unregisterField,
+        clearFieldError,
         handleSubmit,
       }}
     >

--- a/packages/core/lib/Form.tsx
+++ b/packages/core/lib/Form.tsx
@@ -26,12 +26,12 @@ const Form: RefForwardingComponent<FormHandles, FormProps> = (
     [],
   );
 
-  const getFieldValue = useCallback(({ ref, path, getValue }: UnformField) => {
+  const getFieldValue = useCallback(({ ref, getValue, path }: UnformField) => {
     if (getValue) {
       return getValue(ref);
     }
 
-    return dot.pick(path, ref);
+    return path && dot.pick(path, ref);
   }, []);
 
   const setFieldValue = useCallback(
@@ -40,7 +40,7 @@ const Form: RefForwardingComponent<FormHandles, FormProps> = (
         return setValue(ref, value);
       }
 
-      return dot.set(path, value, ref as object);
+      return path ? dot.set(path, value, ref as object) : false;
     },
     [],
   );
@@ -51,7 +51,7 @@ const Form: RefForwardingComponent<FormHandles, FormProps> = (
         return clearValue(ref, '');
       }
 
-      return dot.set(path, '', ref as object);
+      return path && dot.set(path, '', ref as object);
     },
     [],
   );
@@ -62,7 +62,7 @@ const Form: RefForwardingComponent<FormHandles, FormProps> = (
         return clearValue(ref, data[name]);
       }
 
-      return dot.set(path, data[name] ? data[name] : '', ref as object);
+      return path && dot.set(path, data[name] ? data[name] : '', ref as object);
     });
   }, []);
 

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -1,13 +1,23 @@
 import { DetailedHTMLProps, FormHTMLAttributes, FormEvent } from 'react';
 
-export interface UnformField {
+interface BaseUnformField<T> {
   name: string;
   ref?: any;
-  path: string;
-  setValue?: Function;
-  getValue?: Function;
-  clearValue?: Function;
+  setValue?: (ref: any, value: T) => void;
+  clearValue?: (ref: any, newValue: T) => void;
 }
+
+export interface PathUnformField<T> extends BaseUnformField<T> {
+  path: string;
+  getValue?: undefined;
+}
+
+export interface FunctionUnformField<T> extends BaseUnformField<T> {
+  path?: undefined;
+  getValue: (ref: any) => T;
+}
+
+export type UnformField<T = any> = PathUnformField<T> | FunctionUnformField<T>;
 
 export interface UnformErrors {
   [key: string]: string;
@@ -17,7 +27,7 @@ export interface UnformContext {
   initialData: object;
   errors: UnformErrors;
   scopePath: string;
-  registerField: (field: UnformField) => void;
+  registerField<T>(field: UnformField<T>): void;
   unregisterField: (name: string) => void;
   handleSubmit: (e?: FormEvent) => void;
 }

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -58,7 +58,7 @@ export interface FormHelpers {
 }
 
 export interface SubmitHandler<T = any> {
-  (data: T, helpers: FormHelpers): void;
+  (data: T, helpers: FormHelpers, event?: FormEvent): void;
 }
 
 export interface FormProps extends Omit<HTMLFormProps, 'onSubmit'> {

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -20,7 +20,7 @@ export interface FunctionUnformField<T> extends BaseUnformField<T> {
 export type UnformField<T = any> = PathUnformField<T> | FunctionUnformField<T>;
 
 export interface UnformErrors {
-  [key: string]: string;
+  [key: string]: string | undefined;
 }
 
 export interface UnformContext {
@@ -29,6 +29,7 @@ export interface UnformContext {
   scopePath: string;
   registerField<T>(field: UnformField<T>): void;
   unregisterField: (name: string) => void;
+  clearFieldError: (fieldName: string) => void;
   handleSubmit: (e?: FormEvent) => void;
 }
 
@@ -41,7 +42,7 @@ type HTMLFormProps = DetailedHTMLProps<
 export interface FormHandles {
   getFieldValue(fieldName: string): any;
   setFieldValue(fieldName: string, value: any): void | boolean;
-  getFieldError(fieldName: string): string;
+  getFieldError(fieldName: string): string | undefined;
   setFieldError(fieldName: string, error: string): void;
   clearField(fieldName: string): void;
   getData(): object;

--- a/packages/core/lib/useField.ts
+++ b/packages/core/lib/useField.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 
 import dot from 'dot-object';
 
@@ -14,15 +14,22 @@ export default function useField(name: string) {
     registerField,
   } = useContext<UnformContext>(FormContext);
 
-  const fieldName = scopePath ? `${scopePath}.${name}` : name;
+  const fieldName = useMemo(() => {
+    return scopePath ? `${scopePath}.${name}` : name;
+  }, [name, scopePath]);
+
+  const defaultValue = useMemo(() => {
+    return dot.pick(fieldName, initialData);
+  }, [fieldName, initialData]);
+
+  const error = useMemo(() => {
+    return errors[fieldName];
+  }, [errors, fieldName]);
 
   useEffect(() => () => unregisterField(fieldName), [
     fieldName,
     unregisterField,
   ]);
-
-  const defaultValue = dot.pick(fieldName, initialData);
-  const error = errors[fieldName];
 
   return {
     fieldName,

--- a/packages/core/lib/useField.ts
+++ b/packages/core/lib/useField.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo } from 'react';
+import { useContext, useEffect, useMemo, useCallback } from 'react';
 
 import dot from 'dot-object';
 
@@ -12,6 +12,7 @@ export default function useField(name: string) {
     scopePath,
     unregisterField,
     registerField,
+    clearFieldError,
   } = useContext<UnformContext>(FormContext);
 
   const fieldName = useMemo(() => {
@@ -26,6 +27,10 @@ export default function useField(name: string) {
     return errors[fieldName];
   }, [errors, fieldName]);
 
+  const clearError = useCallback(() => {
+    clearFieldError(fieldName);
+  }, [clearFieldError, fieldName]);
+
   useEffect(() => () => unregisterField(fieldName), [
     fieldName,
     unregisterField,
@@ -35,6 +40,7 @@ export default function useField(name: string) {
     fieldName,
     registerField,
     defaultValue,
+    clearError,
     error,
   };
 }

--- a/packages/mobile/__tests__/Form.spec.tsx
+++ b/packages/mobile/__tests__/Form.spec.tsx
@@ -43,6 +43,7 @@ test('it should return data with submits', async () => {
   expect(submitMock).toBeCalledWith(
     { name: 'John Doe' },
     { reset: expect.any(Function) },
+    undefined,
   );
 });
 
@@ -65,5 +66,6 @@ test('it should be able to set initial data', async () => {
   expect(submitMock).toBeCalledWith(
     { name: 'John Doe' },
     { reset: expect.any(Function) },
+    undefined,
   );
 });

--- a/packages/mobile/__tests__/components/Input.tsx
+++ b/packages/mobile/__tests__/components/Input.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, memo } from 'react';
 import { TextInput, TextInputProps, Text } from 'react-native';
 
-import { useField } from '@unform/core';
+import { useField } from '../../../core/lib';
 
 interface Props {
   name: string;
@@ -11,33 +11,37 @@ interface Props {
 type InputProps = TextInputProps & Props;
 
 function Input({ name, label, multiline = false, ...rest }: InputProps) {
-  const ref = useRef<TextInput>(null);
+  const inputRef: any = useRef(null);
 
   const { fieldName, registerField, defaultValue, error } = useField(name);
 
   useEffect(() => {
-    if (ref.current) {
-      registerField({
-        name: fieldName,
-        ref: ref.current,
-        path: '_lastNativeText',
-        getValue(inputRef: any) {
-          return inputRef._lastNativeText;
-        },
-        setValue(inputRef: any, text: string) {
-          inputRef.setNativeProps({ text });
-          inputRef._lastNativeText = text;
-        },
-      });
-    }
-  }, [fieldName, registerField]);
+    inputRef.current.value = defaultValue;
+  }, [defaultValue]);
+
+  useEffect(() => {
+    registerField({
+      name: fieldName,
+      ref: inputRef.current,
+      clearValue(ref: any) {
+        ref.value = '';
+        ref.clear();
+      },
+      setValue(ref: any, value: string) {
+        ref.setNativeProps({ text: value });
+        inputRef.current.value = value;
+      },
+      getValue(ref: any) {
+        return ref.value;
+      },
+    });
+  }, [defaultValue, fieldName, registerField]);
 
   const props = {
     ...rest,
-    ref,
     id: fieldName,
     name: fieldName,
-    value: defaultValue,
+    defaultValue,
     multiline,
   };
 
@@ -45,7 +49,15 @@ function Input({ name, label, multiline = false, ...rest }: InputProps) {
     <>
       {label && <Text>{label}</Text>}
 
-      <TextInput ref={ref} {...props} />
+      <TextInput
+        ref={inputRef}
+        onChangeText={value => {
+          if (inputRef.current) {
+            inputRef.current.value = value;
+          }
+        }}
+        {...props}
+      />
 
       {error && <Text>{error}</Text>}
     </>


### PR DESCRIPTION
Did some changes to Unform due to some issues in the past weeks.

## Changes proposed

### Add value typing to registerField

If we were using TypeScript and Unform, there was no easy way to set the value type, but now we can do:
```ts
registerField<Date>({
  name: fieldName,
  ref: inputRef.current,
  setValue(ref, value) {
    // value will automatically have Date type
  },
  getValue(ref) {
    // typing error, should return a Date
    return 'test'; 
  }
})
```

### `path` not required anymore when `getValue` is present

Now, if an input has the `getValue` property in `registerField`, we won't need to pass `path` property anymore:

#### With `getValue`

```js
registerField({
  name: fieldName,
  ref: inputRef.current,
  getValue(ref) {
    // return value manually
    return inputRef.current.value; 
  }
})
```

#### With `path`

```js
registerField({
  name: fieldName,
  ref: inputRef.current,
  path: 'value'
})
```

### Adding/removing field does not cause rerender anymore

Changed fields variable to a ref instead of a state inside unform, so we don't need to rerender all the form structure when a new field is added or removed improving performance a little bit more.

### Return form event in submit handler

In web there was no way to access the native form event in the submit handler. Now we can access it as the third parameter in the `onSubmit` function.

```js
function handleSubmit(data, { reset }, event) {
  console.log(event);
}
```

### Enable `setData` with values as objects or arrays

Until now, Unform didn't handle well `setData` on inputs that values weren't only strings, numbers or booleans, so objects and arrays weren't been sent to the input at all.

Now Unform can set values as objects/arrays to inputs, for example, imagine if you have a input called `tech` that it's value is stored as `{ id: 5, title: 'React' }`, now you can set it's initial value as:

```js
formRef.current.setData({
  tech: { id: 5, title: 'React' }
})
```

> This was not possible before as unform would try to parse each object property as new inputs named `tech.id` and `tech.title` respectively.

### Add `clearError` function to `useField` hook

As some users were asking for the functionality of clearing input errors on focus, Unform now returns a `clearError` function from `useField` so you can use it to clear the error.

```js
const { clearError } = useField(name);

<input onFocus={clearError} />
```

Fixes #193
Fixes #208
Fixes #215
Fixes #217
Fixes #220 

**Additional context**

I'm working on a lot of improvements on the docs, specially on the unform's integration with React Select, TypeScript, React Native masking libraries and a lot more.

PR's are always welcome! 💜 
