### PR TITLE
Add name validation in useField

### DIFF
--- a/packages/core/lib/useField.ts
+++ b/packages/core/lib/useField.ts
@@ -15,6 +15,10 @@ export default function useField(name: string) {
     clearFieldError,
   } = useContext<UnformContext>(FormContext);
 
+  if (!name) {
+    throw new Error('You need to provide the "name" prop.');
+  }
+
   const fieldName = useMemo(() => {
     return scopePath ? `${scopePath}.${name}` : name;
   }, [name, scopePath]);


### PR DESCRIPTION
<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/unform/blob/master/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- Ensure you have added or ran the appropriate tests for your PR -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
<!--- Describe the change below, including rationale and design decisions -->
As ``useField`` hook makes a lot of operations based on the ``name`` value, we must provide validation for it as well a descriptive error message.

I added the following error message: 

<img width="336" alt="Screen Shot 2020-06-08 at 09 13 53" src="https://user-images.githubusercontent.com/48022589/84029227-6edea780-a968-11ea-9622-d548094fa3d5.png">


<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->
Refer to issue #248 

