### PR TITLE
docs: Fix typo in guides/reset-form.mdx 

### DIFF
--- a/docs/src/docs/guides/reset-form.mdx
+++ b/docs/src/docs/guides/reset-form.mdx
@@ -6,7 +6,7 @@ There are two ways to reset all form data:
 
 ## Reset after submit
 
-Besides the `data`, the `onSubmit` function also receives a second paremeter with form helpers like `resetForm`:
+Besides the `data`, the `onSubmit` function also receives a second parameter with form helpers like `resetForm`:
 
 ```jsx
 export default function SignIn() {


### PR DESCRIPTION
Parameter part had a typo

<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/unform/blob/master/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- Ensure you have added or ran the appropriate tests for your PR -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
Change `paremeter` for `parameter`
<!--- Describe the change below, including rationale and design decisions -->

<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->

<!-- **Additional context** -->
<!-- Add any other context or screenshots about the feature request here. -->
