### PR TITLE
Feat/native support to radio checkbox fields

### DIFF
--- a/packages/core/__tests__/CheckboxField.spec.tsx
+++ b/packages/core/__tests__/CheckboxField.spec.tsx
@@ -1,0 +1,259 @@
+import React, { RefObject } from 'react';
+
+import { fireEvent } from '@testing-library/react';
+
+import '@testing-library/jest-dom/extend-expect.js';
+
+// import { Form } from '../../web/lib';
+import { FormHandles } from '../lib';
+import CheckboxInput from './components/CheckboxInput';
+import render from './utils/RenderTest';
+
+describe('CheckboxField', () => {
+  it('should render radio elements', () => {
+    const { container } = render(
+      <>
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option1" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option2" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option3" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option4" />
+
+        <CheckboxInput name="other-checkbox" type="checkbox" value="option1" />
+        <CheckboxInput name="other-checkbox" type="checkbox" value="option2" />
+      </>,
+    );
+
+    expect(
+      container.querySelectorAll('input[name=some-checkbox]'),
+    ).toHaveLength(4);
+    expect(
+      container.querySelectorAll('input[name=other-checkbox]'),
+    ).toHaveLength(2);
+  });
+  it('should load initial defaultCheck inside checkbox elements', () => {
+    const { getByTestId } = render(
+      <>
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option1" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option2" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option3" />
+      </>,
+      {
+        initialData: { 'some-checkbox': 'option2' },
+      },
+    );
+
+    const option1 = getByTestId('option1') as HTMLInputElement;
+    const option2 = getByTestId('option2') as HTMLInputElement;
+    const option3 = getByTestId('option3') as HTMLInputElement;
+
+    expect(option1.checked).toEqual(false);
+    expect(option2.checked).toEqual(true);
+    expect(option3.checked).toEqual(false);
+  });
+  it('should return value from checked checkbox elements on submit', () => {
+    const submitMock = jest.fn();
+    const { getByTestId } = render(
+      <>
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option1" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option2" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option3" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option4" />
+      </>,
+      {
+        onSubmit: submitMock,
+      },
+    );
+
+    fireEvent.change(getByTestId('option1'), {
+      target: { checked: 'true' },
+    });
+    fireEvent.change(getByTestId('option3'), {
+      target: { checked: 'true' },
+    });
+
+    fireEvent.submit(getByTestId('form'));
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        'some-checkbox': ['option1', 'option3'],
+      },
+      {
+        reset: expect.any(Function),
+      },
+      expect.any(Object),
+    );
+  });
+  it('should reset checked checkbox element when reset helper is dispatched', () => {
+    const { getByTestId } = render(
+      <>
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option1" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option2" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option3" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option4" />
+      </>,
+      { onSubmit: (_: any, { reset }: { reset: Function }) => reset() },
+    );
+
+    (getByTestId('option1') as HTMLInputElement).checked = true;
+
+    fireEvent.submit(getByTestId('form'));
+
+    expect((getByTestId('option1') as HTMLInputElement).checked).toBe(false);
+    expect((getByTestId('option2') as HTMLInputElement).checked).toBe(false);
+    expect((getByTestId('option3') as HTMLInputElement).checked).toBe(false);
+    expect((getByTestId('option4') as HTMLInputElement).checked).toBe(false);
+  });
+  it('should check checkbox element when reset is dispatched with default checked', () => {
+    const newData = {
+      'some-checkbox': ['option1', 'option4'],
+    };
+
+    const { getByTestId } = render(
+      <>
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option1" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option2" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option3" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option4" />
+      </>,
+      {
+        onSubmit: (_: any, { reset }: { reset: Function }) => reset(newData),
+      },
+    );
+
+    (getByTestId('option2') as HTMLInputElement).checked = true;
+
+    fireEvent.submit(getByTestId('form'));
+
+    expect((getByTestId('option1') as HTMLInputElement).checked).toBe(true);
+    expect((getByTestId('option2') as HTMLInputElement).checked).toBe(false);
+    expect((getByTestId('option3') as HTMLInputElement).checked).toBe(false);
+    expect((getByTestId('option4') as HTMLInputElement).checked).toBe(true);
+  });
+  it('should be able to have custom clear value function', () => {
+    const { getByTestId } = render(
+      <>
+        <CheckboxInput
+          name="some-checkbox"
+          type="checkbox"
+          value="option1"
+          customClearValue
+        />
+        <CheckboxInput
+          name="some-checkbox"
+          type="checkbox"
+          value="option2"
+          customClearValue
+        />
+        <CheckboxInput
+          name="some-checkbox"
+          type="checkbox"
+          value="customClear"
+          customClearValue
+        />
+        <CheckboxInput
+          name="some-checkbox"
+          type="checkbox"
+          value="option4"
+          customClearValue
+        />
+      </>,
+      {
+        onSubmit: (_: any, { reset }: { reset: Function }) => reset(),
+      },
+    );
+
+    (getByTestId('option2') as HTMLInputElement).checked = true;
+
+    fireEvent.submit(getByTestId('form'));
+
+    expect((getByTestId('option1') as HTMLInputElement).checked).toBe(false);
+    expect((getByTestId('option2') as HTMLInputElement).checked).toBe(false);
+    expect((getByTestId('customClear') as HTMLInputElement).checked).toBe(true);
+    expect((getByTestId('option4') as HTMLInputElement).checked).toBe(false);
+  });
+  it('should be able to have custom get value function', () => {
+    const submitMock = jest.fn();
+    const { getByTestId } = render(
+      <>
+        <CheckboxInput
+          name="some-checkbox"
+          type="checkbox"
+          value="option1"
+          customGetValue
+        />
+        <CheckboxInput
+          name="some-checkbox"
+          type="checkbox"
+          value="option2"
+          customGetValue
+        />
+      </>,
+      {
+        onSubmit: submitMock,
+      },
+    );
+
+    fireEvent.submit(getByTestId('form'));
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        'some-checkbox': 'customGetValue',
+      },
+      {
+        reset: expect.any(Function),
+      },
+      expect.any(Object),
+    );
+  });
+  it('should be able to have custom set value function', () => {
+    const formRef: RefObject<FormHandles> = { current: null };
+    render(
+      <>
+        <CheckboxInput
+          name="some-checkbox"
+          type="checkbox"
+          value="option1"
+          customSetValue
+        />
+        <CheckboxInput
+          name="some-checkbox"
+          type="checkbox"
+          value="customSet"
+          customSetValue
+        />
+        <CheckboxInput
+          name="some-checkbox"
+          type="checkbox"
+          value="option2"
+          customSetValue
+        />
+      </>,
+      {
+        initialData: { 'some-checkbox': 'option1' },
+        onSubmit: (_: any, { reset }: { reset: Function }) => reset(),
+        ref: formRef,
+      },
+    );
+
+    formRef.current?.setData({ 'some-checkbox': 'option1' });
+    expect(formRef.current?.getFieldValue('some-checkbox')).toStrictEqual([
+      'customSet',
+    ]);
+  });
+  it('should be able to manually get field ref', () => {
+    const formRef: RefObject<FormHandles> = { current: null };
+    render(
+      <>
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option1" />
+        <CheckboxInput name="some-checkbox" type="checkbox" value="option2" />
+      </>,
+      {
+        ref: formRef,
+      },
+    );
+
+    const ref = formRef.current?.getFieldRef('some-checkbox');
+    const refNonExistent = formRef.current?.getFieldRef('notexists');
+
+    expect((ref as HTMLInputElement)[0].name).toBe('some-checkbox');
+    expect(refNonExistent).toBe(false);
+  });
+});

--- a/packages/core/__tests__/RadioField.spec.tsx
+++ b/packages/core/__tests__/RadioField.spec.tsx
@@ -1,0 +1,243 @@
+import React, { RefObject } from 'react';
+
+import { fireEvent } from '@testing-library/react';
+
+import '@testing-library/jest-dom/extend-expect.js';
+
+// import { Form } from '../../web/lib';
+import { FormHandles } from '../lib';
+import RadioInput from './components/RadioInput';
+import render from './utils/RenderTest';
+
+describe('RadioField', () => {
+  it('should render radio elements', () => {
+    const { container } = render(
+      <>
+        <RadioInput name="some-radios" type="radio" value="option1" />
+        <RadioInput name="some-radios" type="radio" value="option2" />
+        <RadioInput name="some-radios" type="radio" value="option3" />
+        <RadioInput name="some-radios" type="radio" value="option4" />
+
+        <RadioInput name="another-radios" type="radio" value="option1" />
+        <RadioInput name="another-radios" type="radio" value="option2" />
+      </>,
+    );
+
+    expect(container.querySelectorAll('input[name=some-radios]')).toHaveLength(
+      4,
+    );
+    expect(
+      container.querySelectorAll('input[name=another-radios]'),
+    ).toHaveLength(2);
+  });
+  it('should load initial defaultCheck inside radio elements', () => {
+    const { getByTestId } = render(
+      <>
+        <RadioInput name="some-radio" type="radio" value="option1" />
+        <RadioInput name="some-radio" type="radio" value="option2" />
+        <RadioInput name="some-radio" type="radio" value="option3" />
+      </>,
+      {
+        initialData: { 'some-radio': 'option2' },
+      },
+    );
+
+    const option1 = getByTestId('option1') as HTMLInputElement;
+    const option2 = getByTestId('option2') as HTMLInputElement;
+    const option3 = getByTestId('option3') as HTMLInputElement;
+
+    expect(option1.checked).toEqual(false);
+    expect(option2.checked).toEqual(true);
+    expect(option3.checked).toEqual(false);
+  });
+  it('should return value from checked radio element on submit', () => {
+    const submitMock = jest.fn();
+    const { getByTestId } = render(
+      <>
+        <RadioInput name="some-radio" type="radio" value="option1" />
+        <RadioInput name="some-radio" type="radio" value="option2" />
+      </>,
+      {
+        onSubmit: submitMock,
+      },
+    );
+
+    fireEvent.change(getByTestId('option1'), {
+      target: { checked: 'true' },
+    });
+
+    fireEvent.submit(getByTestId('form'));
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        'some-radio': 'option1',
+      },
+      {
+        reset: expect.any(Function),
+      },
+      expect.any(Object),
+    );
+  });
+  it('should reset checked radio element when reset helper is dispatched', () => {
+    const { getByTestId } = render(
+      <>
+        <RadioInput name="some-radio" type="radio" value="option1" />
+      </>,
+      { onSubmit: (_: any, { reset }: { reset: Function }) => reset() },
+    );
+
+    (getByTestId('option1') as HTMLInputElement).checked = true;
+
+    fireEvent.submit(getByTestId('form'));
+
+    expect((getByTestId('option1') as HTMLInputElement).checked).toBe(false);
+  });
+  it('should check radio element when reset is dispatched with default checked', () => {
+    const newData = {
+      'some-radio': 'option1',
+    };
+
+    const { getByTestId } = render(
+      <>
+        <RadioInput name="some-radio" type="radio" value="option1" />
+        <RadioInput name="some-radio" type="radio" value="option2" />
+      </>,
+      {
+        onSubmit: (_: any, { reset }: { reset: Function }) => reset(newData),
+      },
+    );
+
+    (getByTestId('option2') as HTMLInputElement).checked = true;
+
+    fireEvent.submit(getByTestId('form'));
+
+    expect((getByTestId('option1') as HTMLInputElement).checked).toBe(true);
+    expect((getByTestId('option2') as HTMLInputElement).checked).toBe(false);
+  });
+  it('should be able to have custom clear value function', () => {
+    const { getByTestId } = render(
+      <>
+        <RadioInput
+          name="some-radio"
+          type="radio"
+          value="option1"
+          customClearValue
+        />
+        <RadioInput
+          name="some-radio"
+          type="radio"
+          value="option2"
+          customClearValue
+        />
+      </>,
+      {
+        onSubmit: (_: any, { reset }: { reset: Function }) => reset(),
+      },
+    );
+
+    (getByTestId('option2') as HTMLInputElement).checked = true;
+
+    fireEvent.submit(getByTestId('form'));
+
+    expect((getByTestId('option2') as HTMLInputElement).checked).toBe(false);
+    expect((getByTestId('option1') as HTMLInputElement).checked).toBe(false);
+  });
+  it('should be able to have custom get value function', () => {
+    const submitMock = jest.fn();
+    const { getByTestId } = render(
+      <>
+        <RadioInput
+          name="some-radio"
+          type="radio"
+          value="option1"
+          customGetValue
+        />
+        <RadioInput
+          name="some-radio"
+          type="radio"
+          value="option2"
+          customGetValue
+        />
+      </>,
+      {
+        onSubmit: submitMock,
+      },
+    );
+
+    fireEvent.submit(getByTestId('form'));
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        'some-radio': 'customGetValue',
+      },
+      {
+        reset: expect.any(Function),
+      },
+      expect.any(Object),
+    );
+  });
+  it('should be able to have custom set value function', () => {
+    const formRef: RefObject<FormHandles> = { current: null };
+    render(
+      <>
+        <RadioInput
+          name="some-radio"
+          type="radio"
+          value="option1"
+          customSetValue
+        />
+        <RadioInput
+          name="some-radio"
+          type="radio"
+          value="customSetValue"
+          customSetValue
+        />
+        <RadioInput
+          name="some-radio"
+          type="radio"
+          value="option2"
+          customSetValue
+        />
+      </>,
+      {
+        initialData: { 'some-radio': 'option1' },
+        onSubmit: (_: any, { reset }: { reset: Function }) => reset(),
+        ref: formRef,
+      },
+    );
+
+    formRef.current?.setData({ 'some-radio': 'option1' });
+    expect(formRef.current?.getFieldValue('some-radio')).toBe('customSetValue');
+  });
+  it('should be able to manually get field ref', () => {
+    const formRef: RefObject<FormHandles> = { current: null };
+    render(
+      <>
+        <RadioInput name="some-radio" type="radio" value="option1" />
+        <RadioInput name="some-radio" type="radio" value="option2" />
+      </>,
+      {
+        ref: formRef,
+      },
+    );
+
+    const ref = formRef.current?.getFieldRef('some-radio');
+    const refNonExistent = formRef.current?.getFieldRef('notexists');
+
+    expect((ref as HTMLInputElement)[0].name).toBe('some-radio');
+    expect(refNonExistent).toBe(false);
+  });
+  it('should return null when none radio element is checked', () => {
+    const formRef: RefObject<FormHandles> = { current: null };
+    render(
+      <>
+        <RadioInput name="some-radio" type="radio" value="option1" />
+        <RadioInput name="some-radio" type="radio" value="option2" />
+      </>,
+      {
+        ref: formRef,
+      },
+    );
+
+    const value = formRef.current?.getFieldValue('some-radio');
+    expect(value).toBe(null);
+  });
+});

--- a/packages/core/__tests__/components/CheckboxInput.tsx
+++ b/packages/core/__tests__/components/CheckboxInput.tsx
@@ -67,7 +67,7 @@ function Input({
     name: fieldName,
     'data-testid': value,
     'aria-label': fieldName,
-    defaultChecked: defaultValue === value,
+    defaultChecked: defaultValue && defaultValue.includes(value),
   };
 
   return (

--- a/packages/core/__tests__/components/CheckboxInput.tsx
+++ b/packages/core/__tests__/components/CheckboxInput.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useRef, memo } from 'react';
+
+import { useField } from '../../lib';
+
+interface Props {
+  name: string;
+  value: string;
+  label?: string;
+  customClearValue?: boolean;
+  customGetValue?: boolean;
+  customSetValue?: boolean;
+}
+
+type InputProps = JSX.IntrinsicElements['input'] & Props;
+
+function clearValue(refs) {
+  refs.forEach(ref => {
+    ref.value === 'customClear' ? (ref.checked = true) : (ref.checked = false);
+  });
+}
+
+function getValue() {
+  return 'customGetValue';
+}
+
+function setValue(refs) {
+  refs.forEach(ref => {
+    ref.value === 'customSet' ? (ref.checked = true) : (ref.checked = false);
+  });
+}
+
+function Input({
+  name,
+  value,
+  label,
+  customGetValue,
+  customSetValue,
+  customClearValue,
+  ...rest
+}: InputProps) {
+  const ref = useRef<HTMLInputElement>(null);
+  const { fieldName, registerField, defaultValue } = useField(name);
+
+  useEffect(() => {
+    if (ref.current) {
+      registerField({
+        name: fieldName,
+        ref: ref.current,
+        type: 'checkbox',
+        ...(customSetValue && { setValue }),
+        ...(customClearValue && { clearValue }),
+        ...(customGetValue ? { getValue } : { path: 'value' }),
+      });
+    }
+  }, [
+    customClearValue,
+    customGetValue,
+    customSetValue,
+    fieldName,
+    registerField,
+  ]);
+
+  const props = {
+    ...rest,
+    ref,
+    value,
+    name: fieldName,
+    'data-testid': value,
+    'aria-label': fieldName,
+    defaultChecked: defaultValue === value,
+  };
+
+  return (
+    <>
+      {label && <label htmlFor={value}>{label}</label>}
+
+      <input {...(props as InputProps)} />
+    </>
+  );
+}
+
+export default memo(Input);

--- a/packages/core/__tests__/components/RadioInput.tsx
+++ b/packages/core/__tests__/components/RadioInput.tsx
@@ -69,7 +69,7 @@ function Input({
     name: fieldName,
     'data-testid': value,
     'aria-label': fieldName,
-    defaultChecked: defaultValue === value,
+    defaultChecked: defaultValue && defaultValue.includes(value),
   };
 
   return (

--- a/packages/core/__tests__/components/RadioInput.tsx
+++ b/packages/core/__tests__/components/RadioInput.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useRef, memo } from 'react';
+
+import { useField } from '../../lib';
+
+interface Props {
+  name: string;
+  value: string;
+  label?: string;
+  customClearValue?: boolean;
+  customGetValue?: boolean;
+  customSetValue?: boolean;
+}
+
+type InputProps = JSX.IntrinsicElements['input'] & Props;
+
+function clearValue(refs) {
+  refs.forEach(ref => {
+    ref.checked = false;
+  });
+}
+
+function getValue() {
+  return 'customGetValue';
+}
+
+function setValue(refs) {
+  refs.forEach(ref => {
+    ref.value === 'customSetValue'
+      ? (ref.checked = true)
+      : (ref.checked = false);
+  });
+}
+
+function Input({
+  name,
+  value,
+  label,
+  customGetValue,
+  customSetValue,
+  customClearValue,
+  ...rest
+}: InputProps) {
+  const ref = useRef<HTMLInputElement>(null);
+  const { fieldName, registerField, defaultValue } = useField(name);
+
+  useEffect(() => {
+    if (ref.current) {
+      registerField({
+        name: fieldName,
+        ref: ref.current,
+        type: 'radio',
+        ...(customSetValue && { setValue }),
+        ...(customClearValue && { clearValue }),
+        ...(customGetValue ? { getValue } : { path: 'value' }),
+      });
+    }
+  }, [
+    customClearValue,
+    customGetValue,
+    customSetValue,
+    fieldName,
+    registerField,
+  ]);
+
+  const props = {
+    ...rest,
+    ref,
+    value,
+    name: fieldName,
+    'data-testid': value,
+    'aria-label': fieldName,
+    defaultChecked: defaultValue === value,
+  };
+
+  return (
+    <>
+      {label && <label htmlFor={value}>{label}</label>}
+
+      <input {...(props as InputProps)} />
+    </>
+  );
+}
+
+export default memo(Input);

--- a/packages/core/lib/Fields/CheckboxField.ts
+++ b/packages/core/lib/Fields/CheckboxField.ts
@@ -1,0 +1,62 @@
+import { BaseField, UnformField } from '../types';
+
+class CheckboxField<T = any[]> implements BaseField<T> {
+  protected ref: any = [];
+
+  protected path = '';
+
+  constructor(field: UnformField) {
+    const {
+      ref,
+      path,
+      getValue: customGetValue,
+      setValue: customSetValue,
+      clearValue: customClearValue,
+    } = field;
+
+    this.addRef(ref);
+    this.path = path || 'value';
+
+    if (customGetValue) {
+      this.getValue = () => customGetValue(this.ref);
+    }
+
+    if (customSetValue) {
+      this.setValue = (value: any) => customSetValue(this.ref, value);
+    }
+
+    if (customClearValue) {
+      this.clearValue = newValue => customClearValue(this.ref, newValue);
+    }
+  }
+
+  addRef(ref: any) {
+    this.ref.push(ref);
+  }
+
+  getRef() {
+    return this.ref;
+  }
+
+  getValue(): T {
+    return this.ref.filter(ref => ref.checked).map(ref => ref.value);
+  }
+
+  setValue(value: T[]): void {
+    this.ref.forEach(ref => {
+      if (value.includes(ref.value)) {
+        ref.checked = true;
+      }
+    });
+  }
+
+  clearValue(value: T[]): void {
+    this.ref.forEach(ref => {
+      ref.checked = false;
+    });
+
+    if (value) this.setValue(value);
+  }
+}
+
+export default CheckboxField;

--- a/packages/core/lib/Fields/Field.ts
+++ b/packages/core/lib/Fields/Field.ts
@@ -1,0 +1,54 @@
+import { BaseField, UnformField } from '../types';
+
+class Field<T> implements BaseField<T> {
+  private ref: any;
+
+  private path = '';
+
+  constructor(field: UnformField) {
+    const {
+      ref,
+      path,
+      getValue: customGetValue,
+      setValue: customSetValue,
+      clearValue: customClearValue,
+    } = field;
+
+    this.addRef(ref);
+    this.path = path || 'value';
+
+    if (customGetValue) {
+      this.getValue = () => customGetValue(this.ref);
+    }
+
+    if (customSetValue) {
+      this.setValue = (value: any) => customSetValue(this.ref, value);
+    }
+
+    if (customClearValue) {
+      this.clearValue = () => customClearValue(this.ref, '');
+    }
+  }
+
+  addRef(ref: any) {
+    this.ref = ref;
+  }
+
+  getRef(): any {
+    return this.ref;
+  }
+
+  getValue(): T {
+    return this.ref[this.path];
+  }
+
+  setValue(value: T | string): void {
+    this.ref[this.path] = value;
+  }
+
+  clearValue(value?: T): void {
+    this.setValue(value || '');
+  }
+}
+
+export default Field;

--- a/packages/core/lib/Fields/RadioField.ts
+++ b/packages/core/lib/Fields/RadioField.ts
@@ -1,0 +1,64 @@
+import { BaseField, UnformField } from '../types';
+
+class RadioField<T> implements BaseField<T> {
+  protected ref: any = [];
+
+  protected path = '';
+
+  constructor(field: UnformField) {
+    const {
+      ref,
+      path,
+      getValue: customGetValue,
+      setValue: customSetValue,
+      clearValue: customClearValue,
+    } = field;
+
+    this.addRef(ref);
+    this.path = path || 'value';
+
+    if (customGetValue) {
+      this.getValue = () => customGetValue(this.ref);
+    }
+
+    if (customSetValue) {
+      this.setValue = (value: any) => customSetValue(this.ref, value);
+    }
+
+    if (customClearValue) {
+      this.clearValue = () => customClearValue(this.ref, '');
+    }
+  }
+
+  addRef(ref: any) {
+    this.ref.push(ref);
+  }
+
+  getRef() {
+    return this.ref;
+  }
+
+  getValue(): T {
+    const checked = this.ref.find(ref => ref.checked);
+
+    return checked ? checked[this.path] : null;
+  }
+
+  setValue(value: T | string): void {
+    const item = this.ref.find(ref => ref[this.path] === value);
+
+    if (item) {
+      item.checked = true;
+    }
+  }
+
+  clearValue(value?: T): void {
+    this.ref.forEach(ref => {
+      ref.checked = false;
+    });
+
+    if (value) this.setValue(value);
+  }
+}
+
+export default RadioField;

--- a/packages/core/lib/Fields/index.ts
+++ b/packages/core/lib/Fields/index.ts
@@ -1,0 +1,8 @@
+import { UnformField } from '../types';
+import Field from './Field';
+
+function createFieldFactory(field: UnformField) {
+  return new Field(field);
+}
+
+export default createFieldFactory;

--- a/packages/core/lib/Fields/index.ts
+++ b/packages/core/lib/Fields/index.ts
@@ -1,8 +1,14 @@
 import { UnformField } from '../types';
 import Field from './Field';
+import RadioField from './RadioField';
 
 function createFieldFactory(field: UnformField) {
-  return new Field(field);
+  switch (field.type) {
+    case 'radio':
+      return new RadioField(field);
+    default:
+      return new Field(field);
+  }
 }
 
 export default createFieldFactory;

--- a/packages/core/lib/Fields/index.ts
+++ b/packages/core/lib/Fields/index.ts
@@ -1,13 +1,16 @@
 import { UnformField } from '../types';
+import CheckboxField from './CheckboxField';
 import Field from './Field';
 import RadioField from './RadioField';
 
-function createFieldFactory(field: UnformField) {
+function createFieldFactory<T>(field: UnformField<T>) {
   switch (field.type) {
+    case 'checkbox':
+      return new CheckboxField<T[]>(field);
     case 'radio':
-      return new RadioField(field);
+      return new RadioField<T>(field);
     default:
-      return new Field(field);
+      return new Field<T>(field);
   }
 }
 

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -3,7 +3,7 @@ import { DetailedHTMLProps, FormHTMLAttributes, FormEvent } from 'react';
 interface BaseUnformField<T> {
   name: string;
   ref?: any;
-  type?: 'radio' | 'default';
+  type?: 'radio' | 'checkbox' | 'default';
   setValue?: (ref: any, value: T) => void;
   clearValue?: (ref: any, newValue: T) => void;
 }
@@ -21,11 +21,11 @@ export interface FunctionUnformField<T> extends BaseUnformField<T> {
 export type UnformField<T = any> = PathUnformField<T> | FunctionUnformField<T>;
 
 export interface BaseField<T> {
-  addRef: (ref: any) => void;
-  getRef: () => any;
-  getValue: () => T | null;
-  setValue: (value: T) => void;
-  clearValue: (value?: T) => void;
+  addRef(ref: any): void;
+  getRef(): any;
+  getValue(): T | null;
+  setValue(value: string | T | T[]): void;
+  clearValue(value?: T | T[]): void;
 }
 
 export interface UnformFields<T = any> {

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -19,6 +19,18 @@ export interface FunctionUnformField<T> extends BaseUnformField<T> {
 
 export type UnformField<T = any> = PathUnformField<T> | FunctionUnformField<T>;
 
+export interface BaseField<T> {
+  addRef: (ref: any) => void;
+  getRef: () => any;
+  getValue: () => T | null;
+  setValue: (value: T) => void;
+  clearValue: (value?: T) => void;
+}
+
+export interface UnformFields<T = any> {
+  [fieldName: string]: BaseField<T>;
+}
+
 export interface UnformErrors {
   [key: string]: string | undefined;
 }
@@ -29,7 +41,7 @@ export interface UnformContext {
   scopePath: string;
   registerField<T>(field: UnformField<T>): void;
   unregisterField: (name: string) => void;
-  clearFieldError: (fieldName: string) => void;
+  setErrors: React.Dispatch<React.SetStateAction<UnformErrors>>;
   handleSubmit: (e?: FormEvent) => void;
 }
 

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -3,6 +3,7 @@ import { DetailedHTMLProps, FormHTMLAttributes, FormEvent } from 'react';
 interface BaseUnformField<T> {
   name: string;
   ref?: any;
+  type?: 'radio' | 'default';
   setValue?: (ref: any, value: T) => void;
   clearValue?: (ref: any, newValue: T) => void;
 }

--- a/packages/core/lib/useField.ts
+++ b/packages/core/lib/useField.ts
@@ -12,7 +12,7 @@ export default function useField(name: string) {
     scopePath,
     unregisterField,
     registerField,
-    clearFieldError,
+    setErrors,
   } = useContext<UnformContext>(FormContext);
 
   if (!name) {
@@ -32,8 +32,8 @@ export default function useField(name: string) {
   }, [errors, fieldName]);
 
   const clearError = useCallback(() => {
-    clearFieldError(fieldName);
-  }, [clearFieldError, fieldName]);
+    setErrors(state => ({ ...state, [fieldName]: undefined }));
+  }, [setErrors, fieldName]);
 
   useEffect(() => () => unregisterField(fieldName), [
     fieldName,

--- a/packages/core/lib/useFormFields.ts
+++ b/packages/core/lib/useFormFields.ts
@@ -1,0 +1,30 @@
+import { useRef, useCallback } from 'react';
+
+import createFieldFactory from './Fields';
+import { UnformFields, UnformField } from './types';
+
+const useFormField = () => {
+  const fields = useRef<UnformFields>({});
+
+  const getFieldByName = useCallback(
+    fieldName => fields.current[fieldName],
+    [],
+  );
+
+  const registerField = useCallback((field: UnformField) => {
+    fields.current[field.name] = createFieldFactory(field);
+  }, []);
+
+  const unregisterField = useCallback((fieldName: string) => {
+    delete fields.current[fieldName];
+  }, []);
+
+  return {
+    getFieldByName,
+    registerField,
+    unregisterField,
+    fields: fields.current,
+  };
+};
+
+export default useFormField;

--- a/packages/core/lib/useFormFields.ts
+++ b/packages/core/lib/useFormFields.ts
@@ -11,9 +11,19 @@ const useFormField = () => {
     [],
   );
 
-  const registerField = useCallback((field: UnformField) => {
-    fields.current[field.name] = createFieldFactory(field);
-  }, []);
+  const registerField = useCallback(
+    (field: UnformField) => {
+      const fieldExistent = getFieldByName(field.name);
+
+      if (fieldExistent) {
+        fieldExistent.addRef(field.ref);
+        return;
+      }
+
+      fields.current[field.name] = createFieldFactory(field);
+    },
+    [getFieldByName],
+  );
 
   const unregisterField = useCallback((fieldName: string) => {
     delete fields.current[fieldName];


### PR DESCRIPTION
<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/unform/blob/master/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- Ensure you have added or ran the appropriate tests for your PR -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
<!--- Describe the change below, including rationale and design decisions -->
This proposes a default way to handle with radio and checkbox elements. On registerField you could pass a type ('radio' | 'checkbox' | 'default') that already contains default behavior (this means getFieldValue, setFieldValue, clearFieldValue to each type). If type is not passed so it assumes the default behaviour like before, doesn't change anything. The option to require a type on registerField is give a freedom to user could create anything that want, only informing the behaviour she/he would like for your components. 

How get that:
1. Move concerns about collection (_registerField_, _unregisterFIeld_, _getFieldByName_ and _fields_) from **formProvider** to **useFormField**.
2. Move concerns about each field (_getFieldValue_, _setFieldValue_, _clearFieldValue_) from **formProvider** to class **Field**.
3. Create CheckboxField and RadioField classes, each of them with respectivaly behaviour.
4. registerField now calls a factory that returns a instance of checkbox, radio or field, depending on type passed or not.
5. Change `fields: <UnformField[]>` to `fields: { [fieldName: string]: BaseField }`. Fields continue a RefObject.
6. Fields with the same name and type, 'radio' or 'checkbox', are put together under the same key on fields, don't overriding like before. Type 'default', or without type on registerField, adds only one field per name, if another field with the same name are provide, it will override.
<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->

**Additional context**
<!-- Add any other context or screenshots about the feature request here. -->
How declare a radio input:
```js
import React, { useEffect, useRef } from 'react';
import { useField } from '@unform/core';

interface InputProps extends HTMLInputAttributes {
  name: string;
  value: string;
  label?: string;
}

const Input: React.FC<InputProps> = ({
  name,
  value,
  label,
  ...rest
}: InputProps) => {
  const ref = useRef<HTMLInputElement>(null);
  const { fieldName, registerField, defaultValue } = useField(name);

  useEffect(() => {
      registerField({
        name: fieldName,
        ref: ref.current,
        path: 'value',
        type: 'radio', // Just add this
      });
  }, [fieldName, registerField, ref]);

  return (
    <>
      {label && <label htmlFor={value}>{label}</label>}

      <input
        type="radio"
        name={fieldName}
        value={value}
        id={value}
        ref={ref}
        defaultChecked={defaultValue && defaultValue.includes(value)}
        {...props}
      />
    </>
  );
}

export default Input;

```
