### PR TITLE
docs: Add React Number Format Example

### DIFF
--- a/docs/src/docs/examples/react-number-format.mdx
+++ b/docs/src/docs/examples/react-number-format.mdx
@@ -1,0 +1,74 @@
+---
+title: React Number Format
+---
+
+[React Number Format](https://www.npmjs.com/package/react-number-format) is a popular package that makes it easy to format inputted numbers, allowing to add prefixes, suffixes, decimal formatting and so on.
+
+> ⚠️ All examples below are using **TypeScript**, if you're not using it you can simply remove all type definitions as the `React.FC<Props>` from component definition.
+
+## Simple customizable number format
+
+```tsx lineNumbers=true
+import React, { useEffect, useRef } from 'react';
+import { useField } from '@unform/core';
+import NumberFormat, { NumberFormatProps } from 'react-number-format';
+
+interface IDecimalInputProps extends NumberFormatProps {
+  name: string;
+  prefix?: string;
+  suffix?: string;
+}
+
+const DecimalInput: React.FC<IDecimalInputProps> = ({
+  name,
+  prefix,
+  suffix,
+  ...rest
+}) => {
+  const inputRef = useRef(null);
+  const { fieldName, defaultValue, registerField } = useField(name);
+
+  useEffect(() => {
+    registerField({
+      name: fieldName,
+      ref: inputRef.current,
+      getValue: (ref: any) => {
+        if (!ref.state || !ref.state.value) {
+          return '';
+        }
+
+        let value = ref.state.value;
+        if (prefix) {
+          value = value.replace(prefix, '');
+        }
+
+        if (suffix) {
+          value = value.replace(suffix, '');
+        }
+
+        return value;
+      },
+      setValue: (ref: any, value: any) => {
+        if (value) {
+          ref.state.value = parseFloat(value);
+          ref.state.numAsString = value;
+        }
+      },
+    });
+  }, [fieldName, registerField]);
+
+  return (
+    <NumberFormat
+      id={name}
+      ref={inputRef}
+      defaultValue={defaultValue}
+      isNumericString
+      prefix={prefix}
+      suffix={suffix}
+      {...rest}
+    />
+  );
+};
+
+export default DecimalInput;
+```


### PR DESCRIPTION
Adds an example showing how to use unform with
react-number-format, a popular package for
formatting inputted numbers

<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/unform/blob/master/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- Ensure you have added or ran the appropriate tests for your PR -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
Adds an example showing how to integrate unform with react-number-format on the documentation.
<!--- Describe the change below, including rationale and design decisions -->

<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->

