### PR TITLE
feat: Add integration package for react-number-format

### DIFF
--- a/docs/config/sidebar.yml
+++ b/docs/config/sidebar.yml
@@ -51,6 +51,11 @@
     - label: 'TypeScript'
       link: '/recipes/typescript'
 
+- label: Integrations
+  items:
+    - label: react-number-format
+      link: /integrations/react-number-format
+
 - label: Examples
   items:
     - label: 'File input'

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,10 +2,9 @@
   "name": "unform.dev",
   "private": true,
   "version": "1.0.0",
-  "description": "Out of the box Gatsby Starter for creating documentation websites easily and quickly. With support for MDX, code highlight, Analytics, SEO and more",
+  "description": "Unform documentation website",
   "author": "João Pedro Schmitz <hey@joaopedro.dev> (@jpedroschmitz)",
   "license": "MIT",
-  "starter-name": "gatsby-starter-rocket-docs",
   "dependencies": {
     "@rocketseat/gatsby-theme-docs": "^2.3.0",
     "@unform/core": "^2.1.6",

--- a/docs/src/docs/integrations/react-number-format.mdx
+++ b/docs/src/docs/integrations/react-number-format.mdx
@@ -1,0 +1,145 @@
+---
+title: How to integrate Unform with react-number-format
+description: How to easily integrate Unform with react-number-format
+---
+
+> This is a beta version of our new integration with [react-number-format](https://github.com/s-yadav/react-number-format)!
+
+The package `@unform/react-number-format` integrates Unform with [react-number-format](https://github.com/s-yadav/react-number-format). By default, it
+returns the value for the input, without masks.
+
+## Installation
+
+You can install with Yarn or NPM.
+
+**Yarn**
+
+```sh
+yarn add @unform/react-number-format react-number-format
+```
+
+**NPM**
+
+```sh
+npm i @unform/react-number-format react-number-format
+```
+
+## Quick start
+
+This example illustrates a basic form with using `@unform/react-number-format`:
+
+```jsx
+import { useRef } from 'react'
+
+import { NumberFormat } from '@unform/react-number-format'
+import { Form } from '@unform/web'
+
+export default function App() {
+  const formRef = useRef(null)
+
+  const handleSubmit = data => console.log(data)
+
+  return (
+    <Form
+      ref={formRef}
+      onSubmit={handleSubmit}
+      initialData={{
+        date: '20/03',
+      }}
+    >
+      <NumberFormat name="date" format="##/##" placeholder="MM/YY" />
+
+      <button type="submit">submit</button>
+    </Form>
+  )
+}
+```
+
+If you are using TypeScript:
+
+```tsx
+import { useRef } from 'react'
+
+import { SubmitHandler, FormHandles } from '@unform/core'
+import { NumberFormat } from '@unform/react-number-format'
+import { Form } from '@unform/web'
+
+interface FormData {
+  date: string
+}
+
+export default function App() {
+  const formRef = useRef<FormHandles>(null)
+
+  const handleSubmit: SubmitHandler<FormData> = data => {
+    console.log(data)
+  }
+
+  return (
+    <Form
+      ref={formRef}
+      onSubmit={handleSubmit}
+      initialData={{
+        date: '20/03',
+      }}
+    >
+      <NumberFormat name="date" format="##/##" placeholder="MM/YY" />
+
+      <button type="submit">submit</button>
+    </Form>
+  )
+}
+```
+
+## Creating your Component
+
+If needed, you can also create a component to access errors and customize it
+based on a design system or your own styles.
+
+### JavaScript
+
+```jsx
+import { NumberFormat } from '@unform/react-number-format'
+import { useField } from '@unform/core'
+
+export default function NumberFormatComponent({ name, label, ...rest }) {
+  const { fieldName, error } = useField(name)
+
+  return (
+    <div>
+      <label htmlFor={fieldName}>{label}</label>
+      <NumberFormat id={fieldName} name={name} {...rest} />
+      {error && <span style={{ color: `red` }}>{error}</span>}
+    </div>
+  )
+}
+```
+
+### TypeScript
+
+```tsx
+import { NumberFormat, NumberFormatProps } from '@unform/react-number-format'
+import { useField } from '@unform/core'
+
+interface Props {
+  label: string
+}
+
+type ComponentProps = Props & NumberFormatProps
+
+export default function NumberFormatComponent({
+  name,
+  label,
+  ...rest
+}: ComponentProps) {
+  const { fieldName, error } = useField(name)
+
+  return (
+    <div>
+      <label htmlFor={fieldName}>{label}</label>
+      <NumberFormat id={fieldName} name={name} {...rest} />
+      {error && <span style={{ color: `red` }}>{error}</span>}
+    </div>
+  )
+}
+```

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -9,6 +9,11 @@
       "source": "/examples/radio",
       "destination": "https://github.com/unform/unform/blob/develop/examples/radio.js",
       "permanent": true
+    },
+    {
+      "source": "/react-number-format",
+      "destination": "/integrations/react-number-format",
+      "permanent": false
     }
   ]
 }

--- a/packages/react-number-format/README.md
+++ b/packages/react-number-format/README.md
@@ -1,0 +1,21 @@
+<p align="center">
+  <a href="https://unform.dev">
+    <img src="https://storage.googleapis.com/golden-wind/unform/unform.svg" height="150" width="175" alt="Unform" />
+  </a>
+</p>
+
+<p align="center">Unform for <a href="https://github.com/s-yadav/react-number-format">react-number-format</a></p>
+
+## Overview
+
+This package contains the [Unform](https://unform.dev) integration with [react-number-format](https://github.com/s-yadav/react-number-format).
+
+The documentation is available at [unform.dev/react-number-format](https://unform.dev/react-number-format).
+
+## Need help?
+
+We’re using [GitHub Discussions](https://github.com/unform/unform/discussions) to create conversations around Unform. It is a place for our community to connect with each other around ideas, questions, issues, and suggestions.
+
+## License
+
+MIT © [Rocketseat](https://github.com/Rocketseat)

--- a/packages/react-number-format/__tests__/ReactNumberFormat.spec.tsx
+++ b/packages/react-number-format/__tests__/ReactNumberFormat.spec.tsx
@@ -1,0 +1,87 @@
+import { RefObject } from 'react'
+
+import '@testing-library/jest-dom/extend-expect.js'
+
+import { FormHandles } from '@unform/core'
+
+import { NumberFormat } from '../lib'
+import { render } from './utils/RenderTest'
+
+describe('React Number Format', () => {
+  it('should render the input element', () => {
+    const { container } = render(<NumberFormat name="price" />)
+
+    expect(!!container.querySelector('input[name=price]')).toBe(true)
+    expect(!!container.querySelector('input[inputmode=numeric]')).toBe(true)
+  })
+
+  it('should be able to set and get values', () => {
+    const formRef: RefObject<FormHandles> = { current: null }
+
+    render(
+      <>
+        <NumberFormat
+          name="creditCard"
+          format="#### #### #### ####"
+          placeholder="credit"
+        />
+        <NumberFormat
+          name="price"
+          value={2456981}
+          thousandSeparator
+          placeholder="price"
+        />
+        <NumberFormat name="date" format="##/##" placeholder="MM/YY" />
+      </>,
+      {
+        initialData: { creditCard: '4111111111111111' },
+        render: {
+          ref: formRef,
+        },
+      }
+    )
+
+    if (formRef.current) {
+      formRef.current.setFieldValue('date', '03/00')
+
+      const creditValue = formRef.current.getFieldValue('credit')
+      const priceValue = formRef.current.getFieldValue('price')
+      const dateValue = formRef.current.getFieldValue('date')
+
+      expect(creditValue).toBe('4111111111111111')
+      expect(priceValue).toBe(2456981)
+      expect(dateValue).toBe('03/00')
+    }
+  })
+
+  it('should be able to clear value', () => {
+    const formRef: RefObject<FormHandles> = { current: null }
+
+    render(
+      <>
+        <NumberFormat
+          name="creditCard"
+          format="#### #### #### ####"
+          placeholder="credit"
+        />
+      </>,
+      {
+        initialData: { creditCard: '4111111111111111' },
+        render: {
+          ref: formRef,
+        },
+      }
+    )
+
+    if (formRef.current) {
+      formRef.current.clearField('credit')
+
+      expect(formRef.current.getFieldValue('credit')).toBe('')
+
+      formRef.current.setFieldValue('credit', '4111111111111111')
+      formRef.current.reset()
+
+      expect(formRef.current.getFieldValue('credit')).toBe('')
+    }
+  })
+})

--- a/packages/react-number-format/__tests__/utils/RenderTest.tsx
+++ b/packages/react-number-format/__tests__/utils/RenderTest.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react'
+
+import { render as rtlRender } from '@testing-library/react'
+
+import { Form } from '../../../web/lib'
+
+export function render(children: ReactNode, props: Record<string, any> = {}) {
+  const mockFunction = jest.fn()
+
+  return rtlRender(
+    <Form data-testid="form" onSubmit={mockFunction} {...props}>
+      {children}
+    </Form>
+  )
+}

--- a/packages/react-number-format/jest.config.js
+++ b/packages/react-number-format/jest.config.js
@@ -1,0 +1,12 @@
+const { join } = require('path')
+
+const baseConfig = require('../../jest.config')
+const pkg = require('./package.json')
+
+delete baseConfig.projects
+
+module.exports = {
+  ...baseConfig,
+  displayName: pkg.name,
+  testMatch: [join(__dirname, '__tests__/**/*.spec.{ts,tsx}')],
+}

--- a/packages/react-number-format/lib/NumberFormat.tsx
+++ b/packages/react-number-format/lib/NumberFormat.tsx
@@ -1,0 +1,52 @@
+import { useRef, useEffect } from 'react'
+import ReactNumberFormat, {
+  NumberFormatProps as Props,
+} from 'react-number-format'
+
+import { useField } from '@unform/core'
+
+export interface NumberFormatProps extends Props {
+  name: string
+  onError?: (err: any) => void
+}
+
+export const NumberFormat = ({ name, value, ...rest }: NumberFormatProps) => {
+  const inputRef = useRef<ReactNumberFormat>(null)
+
+  const { fieldName, defaultValue = '', registerField } = useField(name)
+  const defaultInputValue = value || defaultValue
+
+  useEffect(() => {
+    registerField({
+      name: fieldName,
+      ref: inputRef,
+      getValue: (ref: any) => {
+        const { value } = ref?.current.state
+        return value
+      },
+      clearValue: ref => {
+        ref?.current.setState({
+          value: '',
+          floatValue: '',
+          formattedValue: '',
+        })
+      },
+      setValue: (ref, value) => {
+        if (value) {
+          ref?.current.setState({
+            value,
+          })
+        }
+      },
+    })
+  }, [fieldName, registerField, name])
+
+  return (
+    <ReactNumberFormat
+      ref={inputRef}
+      defaultValue={defaultInputValue}
+      name={name}
+      {...rest}
+    />
+  )
+}

--- a/packages/react-number-format/lib/index.ts
+++ b/packages/react-number-format/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './NumberFormat'

--- a/packages/react-number-format/package.json
+++ b/packages/react-number-format/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@unform/react-number-format",
+  "version": "0.0.1",
+  "description": "Unform integration with React Number Format",
+  "author": "João Pedro Schmitz <hey@joaopedro.dev> (https://joaopedro.dev)",
+  "homepage": "https://github.com/unform/unform/tree/main/packages/react-number-format#readme",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
+  "types": "typings/web/lib/index.d.ts",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "dist",
+    "typings"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unform/unform.git"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "@unform/core": "^2.1.6"
+  },
+  "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0",
+    "react-number-format": ">=4.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/unform/unform/issues"
+  },
+  "devDependencies": {
+    "react-number-format": "^4.5.3"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9280,6 +9280,13 @@ react-native@0.63.4:
     use-subscription "^1.0.0"
     whatwg-fetch "^3.0.0"
 
+react-number-format@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.5.3.tgz#c7b99cad759c6ccd7f82379f2f86d2d920c5ff29"
+  integrity sha512-y7+2HtVjQI82Pome1Xxdf8RODZ6vAGwBnao4Iohl8/zhzWpkuLzvquXHXzXuHT6Xija4QddFAGitUbW3dN4sNg==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-refresh@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.4.2.tgz#54a277a6caaac2803d88f1d6f13c1dcfbd81e334"


### PR DESCRIPTION
<!-- If this is your first time, please read our contribution guidelines: (https://github.com/unform/unform/blob/main/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- Ensure you have added or ran the appropriate tests for your PR -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
<!--- Describe the change below, including rationale and design decisions -->

<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->

This PR creates a package that integrates Unform with [react-number-format](https://github.com/s-yadav/react-number-format) 🎉 

The documentation is available [here](https://unform-git-react-number-format-rocketseat.vercel.app/integrations/react-number-format).

**Additional context**
<!-- Add any other context or screenshots about the feature request here. -->

n/a