### PR TITLE
feature: Add `isFormDirty()` function

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,5 +4,6 @@ root = true
 indent_style = space
 indent_size = 2
 charset = utf-8
+end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/packages/core/__tests__/Form.spec.tsx
+++ b/packages/core/__tests__/Form.spec.tsx
@@ -441,4 +441,78 @@ describe('Form', () => {
       expect((getByLabelText('name') as HTMLInputElement).value).toBe('')
     }
   })
+
+  it('should be able to manually get if a form is not dirty', () => {
+    const formRef: RefObject<FormHandles> = { current: null }
+
+    render(
+      <>
+        <Input name="name" />
+        <Input name="more.age" type="number" />
+      </>,
+      {
+        ref: formRef,
+        initialData: { name: 'John Doe', more: { age: 20 } },
+      }
+    )
+
+    if (formRef.current) {
+      expect(formRef.current.isFormDirty()).toBe(false)
+
+      formRef.current.setData({ name: '', more: { age: 30 } })
+      expect(formRef.current.isFormDirty()).toBe(false)
+      expect(formRef.current.getData()).toEqual({
+        name: '',
+        more: { age: '30' },
+      })
+
+      formRef.current.setFieldValue('name', 'John Doe')
+      expect(formRef.current.isFormDirty()).toBe(false)
+      expect(formRef.current.getFieldValue('name')).toBe('John Doe')
+
+      formRef.current.setFieldValue('more.age', 50)
+      expect(formRef.current.isFormDirty()).toBe(false)
+      expect(formRef.current.getFieldValue('more.age')).toBe('50')
+
+      formRef.current.clearField('name')
+      expect(formRef.current.isFormDirty()).toBe(false)
+      expect(formRef.current.getFieldValue('name')).toBe('')
+
+      formRef.current.reset()
+      expect(formRef.current.isFormDirty()).toBe(false)
+      expect(formRef.current.getData()).toEqual({
+        name: '',
+        more: { age: '' },
+      })
+
+      formRef.current.reset({ name: 'John Doe', more: { age: 30 } })
+      expect(formRef.current.isFormDirty()).toBe(false)
+      expect(formRef.current.getData()).toEqual({
+        name: 'John Doe',
+        more: { age: '30' },
+      })
+    }
+  })
+
+  it('should be able to manually get if a form is dirty', () => {
+    const formRef: RefObject<FormHandles> = { current: null }
+
+    const { getByLabelText } = render(
+      <>
+        <Input name="name" />
+      </>,
+      {
+        ref: formRef,
+        initialData: { name: '' },
+      }
+    )
+
+    if (formRef.current) {
+      fireEvent.change(getByLabelText('name'), {
+        target: { value: 'John Doe' },
+      })
+
+      expect(formRef.current.isFormDirty()).toBe(true)
+    }
+  })
 })

--- a/packages/core/lib/types.ts
+++ b/packages/core/lib/types.ts
@@ -28,6 +28,10 @@ export interface UnformErrors {
   [key: string]: string | undefined
 }
 
+export interface UnformOriginalData {
+  [key: string]: any
+}
+
 export interface UnformContext {
   initialData: Record<string, unknown>
   errors: UnformErrors
@@ -58,6 +62,7 @@ export interface FormHandles {
   setErrors(errors: Record<string, string>): void
   reset(data?: Record<string, unknown>): void
   submitForm(): void
+  isFormDirty(): boolean
 }
 
 export interface FormHelpers {


### PR DESCRIPTION
The `isFormDirty()` method validates if any form field has been changed. It can be used to prevent the user from leaving the form without having saved their data first.

<!-- If this is your first time, please read our contribution guidelines: (https://github.com/unform/unform/blob/main/.github/CONTRIBUTING.md) -->

<!-- Verify first that your pull request is not already proposed -->

<!-- Refrain from using any language other than English -->

<!-- Ensure you have added or ran the appropriate tests for your PR -->

<!-- If possible complete *all* sections as described. Don't remove any section. -->

**Changes proposed**
<!--- Describe the change below, including rationale and design decisions -->
This change adds a method to check whether any form field has changed.

This functionality is useful to help prevent the user from exiting the form and losing unsaved data.

How does it work:

1. Saving the original value
The `initialData` will be stored inside the component, in a `useRef` and converted to key and value with `dot.dot(...)`.

2. Updating `ref`
The value contained in `ref` will be updated via `setData`, `reset`, `clearFieldValue` or `setFieldValue`, with `setFieldValue` and `clearFieldValue` updating the specific value of a `ref` property.

3. Validating if something has changed with `isFormDirty()`
We use a loop to validate if any of the `ref` attributes have changed. We retrieve the form data with `parseFormData()` and use `dot.dot(...)` to transform everything into key and value, so we can compare with the value contained in `ref`.

<!--- Include "Fixes #[issue_number]" if you are fixing an existing issue -->
#359 #419

**Additional context**
<!-- Add any other context or screenshots about the feature request here. -->
Usage example:
```TS
useEffect(() => {
  const unlisten = history.block(() => {
    if (formRef.current?.isFormDirty()) {
      return 'Deseja sair sem salvar as alterações?';
    }
  });
  return unlisten;
}, [formRef, history]);
```


